### PR TITLE
Public-key Certificate Authentication

### DIFF
--- a/cmd/uptermd/internal/command/root.go
+++ b/cmd/uptermd/internal/command/root.go
@@ -14,6 +14,7 @@ var (
 	flagWSAddr      string
 	flagNodeAddr    string
 	flagPrivateKeys []string
+	flagHostnames   []string
 	flagNetwork     string
 	flagNetworkOpts []string
 	flagMetricAddr  string
@@ -24,7 +25,7 @@ func Root(logger log.FieldLogger) *cobra.Command {
 	rootCmd := &rootCmd{}
 	cmd := &cobra.Command{
 		Use:   "uptermd",
-		Short: "Upterm daemon",
+		Short: "Upterm Daemon",
 		RunE:  rootCmd.Run,
 	}
 
@@ -32,6 +33,7 @@ func Root(logger log.FieldLogger) *cobra.Command {
 	cmd.PersistentFlags().StringVarP(&flagWSAddr, "ws-addr", "", "", "websocket server address")
 	cmd.PersistentFlags().StringVarP(&flagNodeAddr, "node-addr", "", "", "node address")
 	cmd.PersistentFlags().StringSliceVarP(&flagPrivateKeys, "private-key", "", nil, "server private key")
+	cmd.PersistentFlags().StringSliceVarP(&flagHostnames, "hostname", "", nil, "server hostname for public-key authentication certificate principals. If empty, public-key authentication is used instead.")
 
 	cmd.PersistentFlags().StringVarP(&flagNetwork, "network", "", "mem", "network provider")
 	cmd.PersistentFlags().StringSliceVarP(&flagNetworkOpts, "network-opt", "", nil, "network provider option")
@@ -51,6 +53,7 @@ func (cmd *rootCmd) Run(c *cobra.Command, args []string) error {
 		WSAddr:     flagWSAddr,
 		NodeAddr:   flagNodeAddr,
 		KeyFiles:   flagPrivateKeys,
+		Hostnames:  flagHostnames,
 		Network:    flagNetwork,
 		NetworkOpt: flagNetworkOpts,
 		MetricAddr: flagMetricAddr,

--- a/ftests/ftests_test.go
+++ b/ftests/ftests_test.go
@@ -177,6 +177,19 @@ func (s *Server) start() error {
 		return err
 	}
 
+	var hostSigners []ssh.Signer
+	for _, s := range signers {
+		cs := server.HostCertSigner{
+			Hostnames: []string{"127.0.0.1"},
+		}
+		hostSigner, err := cs.SignCert(s)
+		if err != nil {
+			return err
+		}
+
+		hostSigners = append(hostSigners, hostSigner)
+	}
+
 	network := &server.MemoryProvider{}
 	_ = network.SetOpts(nil)
 
@@ -185,7 +198,8 @@ func (s *Server) start() error {
 
 	s.Server = &server.Server{
 		NodeAddr:        s.SSHAddr(), // node addr is hard coded to ssh addr
-		HostSigners:     signers,
+		HostSigners:     hostSigners,
+		Signers:         signers,
 		NetworkProvider: network,
 		MetricsProvider: provider.NewDiscardProvider(),
 		Logger:          logger,

--- a/ftests/host_test.go
+++ b/ftests/host_test.go
@@ -89,6 +89,10 @@ func testHostClientCallback(t *testing.T, hostURL, nodeAddr string) {
 
 	select {
 	case cc := <-lch:
+		if cc.Id == "" {
+			t.Fatal("client id can't be empty")
+		}
+
 		pk, _, _, _, err := ssh.ParseAuthorizedKey([]byte(ClientPublicKeyContent))
 		if err != nil {
 			t.Fatal(err)

--- a/host/host.go
+++ b/host/host.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math/rand"
 	"net"
 	"net/url"
 	"os"
@@ -154,6 +155,8 @@ type Host struct {
 }
 
 func (c *Host) Run(ctx context.Context) error {
+	rand.Seed(time.Now().UTC().UnixNano())
+
 	u, err := url.Parse(c.Host)
 	if err != nil {
 		return fmt.Errorf("error parsing host url: %s", err)

--- a/host/host.go
+++ b/host/host.go
@@ -264,10 +264,12 @@ func (c *Host) Run(ctx context.Context) error {
 				cid, ok := args[0].(string)
 				if ok {
 					client := clientRepo.Get(cid)
-					logger.WithField("client", client.Addr).Info("Client left")
-					clientRepo.Delete(cid)
-					if c.ClientLeftCallback != nil && client != nil {
-						c.ClientLeftCallback(*client)
+					if client != nil {
+						logger.WithField("client", client.Addr).Info("Client left")
+						clientRepo.Delete(cid)
+						if c.ClientLeftCallback != nil && client != nil {
+							c.ClientLeftCallback(*client)
+						}
 					}
 				}
 			}

--- a/host/internal/reversetunnel.go
+++ b/host/internal/reversetunnel.go
@@ -79,9 +79,9 @@ func (c *ReverseTunnel) Establish(ctx context.Context) (*server.CreateSessionRes
 		// Enforce a restricted set of algorithms for security
 		// TODO: make this configurable if necessary
 		HostKeyAlgorithms: []string{
-			ssh.CertAlgoRSAv01,
 			ssh.CertAlgoED25519v01,
 			ssh.KeyAlgoED25519,
+			ssh.CertAlgoRSAv01,
 			ssh.KeyAlgoRSA,
 		},
 		HostKeyCallback: c.HostKeyCallback,

--- a/host/internal/server.go
+++ b/host/internal/server.go
@@ -124,7 +124,7 @@ type publicKeyHandler struct {
 }
 
 func (h *publicKeyHandler) HandlePublicKey(ctx gssh.Context, key gssh.PublicKey) bool {
-	checker := server.CertChecker{}
+	checker := server.UserCertChecker{}
 	auth, pk, err := checker.Authenticate(ctx.User(), key)
 	if err != nil {
 		h.Logger.WithError(err).Error("error parsing auth request from cert")

--- a/host/internal/server.go
+++ b/host/internal/server.go
@@ -124,13 +124,8 @@ type publicKeyHandler struct {
 }
 
 func (h *publicKeyHandler) HandlePublicKey(ctx gssh.Context, key gssh.PublicKey) bool {
-	cert, ok := key.(*ssh.Certificate)
-	if !ok {
-		h.Logger.Error("public key not a cert")
-		return false
-	}
-
-	auth, pk, err := server.ParseAuthRequestFromCert(ctx.User(), cert)
+	checker := server.CertChecker{}
+	auth, pk, err := checker.Authenticate(ctx.User(), key)
 	if err != nil {
 		h.Logger.WithError(err).Error("error parsing auth request from cert")
 		return false

--- a/host/internal/server.go
+++ b/host/internal/server.go
@@ -130,15 +130,9 @@ func (h *publicKeyHandler) HandlePublicKey(ctx gssh.Context, key gssh.PublicKey)
 		return false
 	}
 
-	auth, err := server.ParseAuthRequestFromCert(ctx.User(), cert)
+	auth, pk, err := server.ParseAuthRequestFromCert(ctx.User(), cert)
 	if err != nil {
-		h.Logger.WithError(err).Info("error parsing auth request from cert")
-		return false
-	}
-
-	pk, _, _, _, err := ssh.ParseAuthorizedKey(auth.AuthorizedKey)
-	if err != nil {
-		h.Logger.WithError(err).Error("authroized key parsing failed")
+		h.Logger.WithError(err).Error("error parsing auth request from cert")
 		return false
 	}
 

--- a/host/signer.go
+++ b/host/signer.go
@@ -70,7 +70,6 @@ func SignersFromFiles(privateKeys []string) ([]ssh.Signer, error) {
 	var signers []ssh.Signer
 	for _, file := range privateKeys {
 		s, err := signerFromFile(file, promptForPassphrase)
-		fmt.Println(err)
 		if err == nil {
 			signers = append(signers, s)
 		}

--- a/server/cert.go
+++ b/server/cert.go
@@ -1,7 +1,9 @@
 package server
 
 import (
+	"crypto/rand"
 	"fmt"
+	"time"
 
 	proto "github.com/golang/protobuf/proto"
 	"github.com/owenthereal/upterm/upterm"
@@ -11,6 +13,18 @@ import (
 var (
 	errCertNotSignedByHost = fmt.Errorf("ssh cert not signed by host")
 )
+
+type CertChecker struct {
+}
+
+func (c *CertChecker) Authenticate(user string, key ssh.PublicKey) (*AuthRequest, ssh.PublicKey, error) {
+	cert, ok := key.(*ssh.Certificate)
+	if !ok {
+		return nil, nil, fmt.Errorf("public key not a cert")
+	}
+
+	return ParseAuthRequestFromCert(user, cert)
+}
 
 // ParseAuthRequestFromCert parses auth request and public key from a cert
 func ParseAuthRequestFromCert(principal string, cert *ssh.Certificate) (*AuthRequest, ssh.PublicKey, error) {
@@ -39,4 +53,43 @@ func ParseAuthRequestFromCert(principal string, cert *ssh.Certificate) (*AuthReq
 	}
 
 	return &auth, key, nil
+}
+
+type CertSigner struct {
+	SessionID   string
+	User        string
+	AuthRequest AuthRequest
+}
+
+func (g *CertSigner) SignCert(signer ssh.Signer) (ssh.Signer, error) {
+	b, err := proto.Marshal(&g.AuthRequest)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling auth request: %w", err)
+	}
+
+	at := time.Now()
+	bt := at.Add(1 * time.Minute) // cert valid for 1 min
+	cert := &ssh.Certificate{
+		Key:             signer.PublicKey(),
+		CertType:        ssh.HostCert,
+		KeyId:           g.SessionID,
+		ValidPrincipals: []string{g.User},
+		ValidAfter:      uint64(at.Unix()),
+		ValidBefore:     uint64(bt.Unix()),
+		Permissions: ssh.Permissions{
+			Extensions: map[string]string{upterm.SSHCertExtension: string(b)},
+		},
+	}
+
+	// TODO: use differnt key to sign
+	if err := cert.SignCert(rand.Reader, signer); err != nil {
+		return nil, fmt.Errorf("error signing host cert: %w", err)
+	}
+
+	cs, err := ssh.NewCertSigner(cert, signer)
+	if err != nil {
+		return nil, fmt.Errorf("error generating host signer: %w", err)
+	}
+
+	return cs, nil
 }

--- a/server/cert.go
+++ b/server/cert.go
@@ -1,0 +1,29 @@
+package server
+
+import (
+	"fmt"
+
+	proto "github.com/golang/protobuf/proto"
+	"github.com/owenthereal/upterm/upterm"
+	"golang.org/x/crypto/ssh"
+)
+
+// TODO: check cert comes from a public key
+func ParseAuthRequestFromCert(principal string, cert *ssh.Certificate) (*AuthRequest, error) {
+	checker := &ssh.CertChecker{}
+	if err := checker.CheckCert(principal, cert); err != nil {
+		return nil, err
+	}
+
+	ext, ok := cert.Permissions.Extensions[upterm.SSHCertExtension]
+	if !ok {
+		return nil, fmt.Errorf("cert missing upterm ssh cert ext")
+	}
+
+	var auth AuthRequest
+	if err := proto.Unmarshal([]byte(ext), &auth); err != nil {
+		return nil, err
+	}
+
+	return &auth, nil
+}

--- a/server/cert.go
+++ b/server/cert.go
@@ -71,7 +71,7 @@ func (g *CertSigner) SignCert(signer ssh.Signer) (ssh.Signer, error) {
 	bt := at.Add(1 * time.Minute) // cert valid for 1 min
 	cert := &ssh.Certificate{
 		Key:             signer.PublicKey(),
-		CertType:        ssh.HostCert,
+		CertType:        ssh.UserCert,
 		KeyId:           g.SessionID,
 		ValidPrincipals: []string{g.User},
 		ValidAfter:      uint64(at.Unix()),

--- a/server/server.go
+++ b/server/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"math/rand"
 	"net"
 	"net/url"
 	"os"
@@ -36,6 +37,8 @@ type Opt struct {
 }
 
 func Start(opt Opt) error {
+	rand.Seed(time.Now().UTC().UnixNano())
+
 	// must always have a ssh addr
 	if opt.SSHAddr == "" {
 		return fmt.Errorf("must specify a ssh address")

--- a/server/server.go
+++ b/server/server.go
@@ -219,12 +219,10 @@ func (s *Server) ServeWithContext(ctx context.Context, sshln net.Listener, wsln 
 				Logger:              s.Logger.WithField("com", "ssh-conn-dialer"),
 			}
 			sp := &sshProxy{
-				HostSigners: s.HostSigners,
-				ConnDialer:  cd,
-				authPiper: authPiper{
-					SessionRepo: sessRepo,
-					NodeAddr:    s.NodeAddr,
-				},
+				HostSigners:     s.HostSigners,
+				NodeAddr:        s.NodeAddr,
+				ConnDialer:      cd,
+				SessionRepo:     sessRepo,
 				Logger:          s.Logger.WithField("com", "ssh-proxy"),
 				MetricsProvider: s.MetricsProvider,
 			}

--- a/server/server.go
+++ b/server/server.go
@@ -82,11 +82,6 @@ func Start(opt Opt) error {
 		hostSigners = append(hostSigners, ss)
 	}
 
-	// Use private-key signers if there is no cert principal
-	if len(hostSigners) == 0 {
-		hostSigners = signers
-	}
-
 	l := log.New()
 	if opt.Debug {
 		l.SetLevel(log.DebugLevel)

--- a/server/sshd.go
+++ b/server/sshd.go
@@ -75,6 +75,15 @@ func (s *sshd) Serve(ln net.Listener) error {
 			return true
 		}),
 		PublicKeyHandler: func(ctx ssh.Context, key ssh.PublicKey) bool {
+			checker := CertChecker{}
+			_, _, err := checker.Authenticate(ctx.User(), key)
+			if err != nil {
+				s.Logger.WithError(err).Error("error parsing auth request from cert")
+				return false
+			}
+
+			// TOOD: validate pk
+
 			return true
 		},
 		ChannelHandlers: make(map[string]ssh.ChannelHandler), // disallow channl requests, e.g. shell

--- a/server/sshd.go
+++ b/server/sshd.go
@@ -75,15 +75,6 @@ func (s *sshd) Serve(ln net.Listener) error {
 			return true
 		}),
 		PublicKeyHandler: func(ctx ssh.Context, key ssh.PublicKey) bool {
-			// This function is never executed when the protocol is ssh.
-			// It acts as an indicator to crypto/ssh that public key auth
-			// is enabled. This allows the ssh router to convert the public
-			// key auth to password auth with public key as the password in
-			// authorized key format.
-			//
-			// However, this function needs to return true to allow publickey
-			// auth when the protocol is websocket.
-			// TODO: validate publickey when it's websocket.
 			return true
 		},
 		ChannelHandlers: make(map[string]ssh.ChannelHandler), // disallow channl requests, e.g. shell

--- a/server/sshd.go
+++ b/server/sshd.go
@@ -86,17 +86,6 @@ func (s *sshd) Serve(ln net.Listener) error {
 			// TODO: validate publickey when it's websocket.
 			return true
 		},
-		PasswordHandler: func(ctx ssh.Context, password string) bool {
-			var auth AuthRequest
-			if err := proto.Unmarshal([]byte(password), &auth); err != nil {
-				return false
-			}
-
-			_, _, _, _, err := ssh.ParseAuthorizedKey(auth.AuthorizedKey)
-			// TODO: validate publickey
-
-			return err == nil
-		},
 		ChannelHandlers: make(map[string]ssh.ChannelHandler), // disallow channl requests, e.g. shell
 		RequestHandlers: map[string]ssh.RequestHandler{
 			streamlocalForwardChannelType:         sh.Handler,

--- a/server/sshd.go
+++ b/server/sshd.go
@@ -75,7 +75,7 @@ func (s *sshd) Serve(ln net.Listener) error {
 			return true
 		}),
 		PublicKeyHandler: func(ctx ssh.Context, key ssh.PublicKey) bool {
-			checker := CertChecker{}
+			checker := UserCertChecker{}
 			_, _, err := checker.Authenticate(ctx.User(), key)
 			if err != nil {
 				s.Logger.WithError(err).Error("error parsing auth request from cert")

--- a/server/sshd_test.go
+++ b/server/sshd_test.go
@@ -40,7 +40,7 @@ func Test_sshd_DisallowSession(t *testing.T) {
 	}
 
 	// Set up cert signer for sshd public key validation
-	cs := CertSigner{
+	cs := UserCertSigner{
 		SessionID: "1234",
 		User:      "owen",
 		AuthRequest: AuthRequest{

--- a/server/sshproxy.go
+++ b/server/sshproxy.go
@@ -103,6 +103,12 @@ func (a authPiper) publicKeyCallback(conn ssh.ConnMetadata, key ssh.PublicKey) (
 	// If public key is a cert, try to parse auth request and public key from it
 	if ok {
 		auth, key, err = ParseAuthRequestFromCert(conn.User(), cert)
+		// The cert is not a upterm cert
+		// Get the public key from cert signature
+		if err == errCertNotSignedByHost {
+			key = cert.SignatureKey
+			err = nil
+		}
 		if err != nil {
 			return ssh.AuthPipeTypeDiscard, nil, fmt.Errorf("error parsing cert: %w", err)
 		}

--- a/server/sshproxy.go
+++ b/server/sshproxy.go
@@ -164,7 +164,7 @@ func (a authPiper) validateClientAuthorizedKey(conn ssh.ConnMetadata, key ssh.Pu
 		return fmt.Errorf("error decoding identifier from user %s: %w", user, err)
 	}
 
-	// Don't vdalite authorized key if:
+	// Don't validate authorized key if:
 	// 1. This is not a client request
 	// 2. The node does not match the request that routing is needed
 	if id.Type != api.Identifier_CLIENT || a.NodeAddr != id.NodeAddr {

--- a/server/sshproxy_test.go
+++ b/server/sshproxy_test.go
@@ -22,6 +22,14 @@ func Test_sshProxy_findUpstream(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	cs := HostCertSigner{
+		Hostnames: []string{"127.0.0.1"},
+	}
+	hostSigner, err := cs.SignCert(signer)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	proxyLn, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)
@@ -35,7 +43,8 @@ func Test_sshProxy_findUpstream(t *testing.T) {
 		Logger:          logger,
 	}
 	proxy := &sshProxy{
-		HostSigners:     []ssh.Signer{signer},
+		HostSigners:     []ssh.Signer{hostSigner},
+		Signers:         []ssh.Signer{signer},
 		NodeAddr:        proxyAddr,
 		ConnDialer:      cd,
 		Logger:          logger,

--- a/server/sshproxy_test.go
+++ b/server/sshproxy_test.go
@@ -36,6 +36,7 @@ func Test_sshProxy_findUpstream(t *testing.T) {
 	}
 	proxy := &sshProxy{
 		HostSigners:     []ssh.Signer{signer},
+		NodeAddr:        proxyAddr,
 		ConnDialer:      cd,
 		Logger:          logger,
 		MetricsProvider: provider.NewDiscardProvider(),

--- a/server/sshrouting.go
+++ b/server/sshrouting.go
@@ -59,8 +59,9 @@ func (p *SSHRouting) Serve(ln net.Listener) error {
 		FindUpstream:  p.FindUpstreamFunc,
 		ServerVersion: upterm.ServerSSHServerVersion,
 	}
-	for _, signer := range p.HostSigners {
-		piper.AddHostKey(signer)
+
+	for _, s := range p.HostSigners {
+		piper.AddHostKey(s)
 	}
 
 	inst := newSSHRoutingInstruments(p.MetricsProvider)

--- a/upterm/const.go
+++ b/upterm/const.go
@@ -17,6 +17,8 @@ const (
 	// misc
 	OpenSSHKeepAliveRequestType = "keepalive@openssh.com"
 
+	SSHCertExtension = "upterm-auth-request"
+
 	EventClientJoined          = "client-joined"
 	EventClientLeft            = "client-left"
 	EventTerminalWindowChanged = "terminal-window-changed"

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -2,8 +2,6 @@ package utils
 
 import (
 	"crypto/ed25519"
-	"crypto/rand"
-	"crypto/rsa"
 	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
@@ -79,12 +77,7 @@ func CreateSigners(privateKeys [][]byte) ([]ssh.Signer, error) {
 			return nil, err
 		}
 
-		rpk, err := rsa.GenerateKey(rand.Reader, 4096)
-		if err != nil {
-			return nil, err
-		}
-
-		for _, pk := range []interface{}{epk, rpk} {
+		for _, pk := range []interface{}{epk} {
 			signer, err := ssh.NewSignerFromKey(pk)
 			if err != nil {
 				return nil, err

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -107,6 +107,10 @@ func GenerateSessionID() string {
 	return uniuri.NewLen(uniuri.UUIDLen)
 }
 
+func GenerateNonce() string {
+	return uniuri.NewLen(32)
+}
+
 func FingerprintSHA256(key ssh.PublicKey) string {
 	hash := sha256.Sum256(key.Marshal())
 	b64hash := base64.StdEncoding.EncodeToString(hash[:])


### PR DESCRIPTION
Make use of public-key certificate authentication: https://github.com/openssh/openssh-portable/blob/master/PROTOCOL.certkeys. The followings are changed:

* Server returns a cert instead of a public key
* SSH proxy and upstream communicated using public-key cert auth, instead of converting to password auth
* Extending ssh cert with upterm extension for internal message passing.
* Host verifies cert from server