### PR TITLE
Make private key optional for `upterm host`

### DIFF
--- a/cmd/upterm/command/host.go
+++ b/cmd/upterm/command/host.go
@@ -34,13 +34,13 @@ func hostCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "host",
 		Short: "Host a terminal session",
-		Long:  "Host a terminal session via a reverse SSH tunnel to the upterm server. By default, the command authenticates against the upterm server using the private keys located at `~/.ssh/id_dsa`, `~/.ssh/id_ecdsa`, `~/.ssh/id_ed25519`, and `~/.ssh/id_rsa`. The host can permit a list of client public keys by specifying an authorized_keys file. By default, the input/output of the host attaches to the input/output of the client's. The host can force the execution of a command after the client joins, and attach the input/output of this command to the client's.",
+		Long:  `Host a terminal session over a reverse SSH tunnel to the Upterm server with the IO of the host and the client attaching to the IO of a command. By default, the command authenticates against the Upterm server using the private key files located at ~/.ssh/id_dsa, ~/.ssh/id_ecdsa, ~/.ssh/id_ed25519, and ~/.ssh/id_rsa. If no private key file is found, the command reads private keys from SSH Agent. If no private key is found from files or SSH Agent, the command falls back to generate one on the fly. To permit authorized clients to join, client public keys can be specified with --authorized-key.`,
 		Example: `  # Host a terminal session that runs $SHELL with
   # client's input/output attaching to the host's
   upterm host
 
   # Host a terminal session that only allows specified public key(s) to connect
-  $ upterm host --authorized-key PATH_TO_PUBLIC_KEY
+  upterm host --authorized-key PATH_TO_PUBLIC_KEY
 
   # Host a session with a custom command.
   upterm host -- docker run --rm -ti ubuntu bash
@@ -63,7 +63,7 @@ func hostCmd() *cobra.Command {
 
 	cmd.PersistentFlags().StringVarP(&flagServer, "server", "", "ssh://uptermd.upterm.dev:22", "upterm server address (required), supported protocols are shh, ws, or wss.")
 	cmd.PersistentFlags().StringVarP(&flagForceCommand, "force-command", "f", "", "force execution of a command and attach its input/output to client's.")
-	cmd.PersistentFlags().StringSliceVarP(&flagPrivateKeys, "private-key", "i", defaultPrivateKeys(homeDir), "private key for public key authentication against the upterm server (required).")
+	cmd.PersistentFlags().StringSliceVarP(&flagPrivateKeys, "private-key", "i", defaultPrivateKeys(homeDir), "private key file for public key authentication against the upterm server")
 	cmd.PersistentFlags().StringVarP(&flagKnownHostsFilename, "known-hosts", "", defaultKnownHost(homeDir), "a file contains the known keys for remote hosts (required).")
 	cmd.PersistentFlags().StringVarP(&flagAuthorizedKeys, "authorized-key", "a", "", "an authorized_keys file that lists public keys that are permitted to connect.")
 	cmd.PersistentFlags().BoolVarP(&flagReadOnly, "read-only", "r", false, "host a read-only session. Clients won't be able to interact.")

--- a/cmd/upterm/command/host.go
+++ b/cmd/upterm/command/host.go
@@ -106,10 +106,6 @@ func validateShareRequiredFlags(c *cobra.Command, args []string) error {
 		}
 	}
 
-	if flagKnownHostsFilename == "" {
-		result = multierror.Append(result, fmt.Errorf("missing flag --known-hosts"))
-	}
-
 	return result
 }
 

--- a/cmd/upterm/command/host.go
+++ b/cmd/upterm/command/host.go
@@ -106,10 +106,6 @@ func validateShareRequiredFlags(c *cobra.Command, args []string) error {
 		}
 	}
 
-	if len(flagPrivateKeys) == 0 {
-		result = multierror.Append(result, fmt.Errorf("missing flag --private-key"))
-	}
-
 	if flagKnownHostsFilename == "" {
 		result = multierror.Append(result, fmt.Errorf("missing flag --known-hosts"))
 	}

--- a/host/host.go
+++ b/host/host.go
@@ -330,6 +330,11 @@ func keyType(t string) string {
 func createFileIfNotExist(file string) error {
 	_, err := os.Stat(file)
 	if os.IsNotExist(err) {
+		dir := filepath.Dir(file)
+		if err := os.MkdirAll(dir, 0700); err != nil {
+			return err
+		}
+
 		file, err := os.Create(file)
 		if err != nil {
 			return err

--- a/host/signer.go
+++ b/host/signer.go
@@ -116,7 +116,16 @@ func SignersFromSSHAgentForKeys(socket string, privateKeys []string) ([]ssh.Sign
 func signersFromSSHAgentForKeys(client agent.Agent, privateKeys []string, promptForPassphrase func(file string) ([]byte, error)) ([]ssh.Signer, error) {
 	// Return all signers from SSH agent if no private key is specified
 	if len(privateKeys) == 0 {
-		return client.Signers()
+		signers, err := client.Signers()
+		if err != nil {
+			return nil, err
+		}
+
+		if len(signers) == 0 {
+			return nil, fmt.Errorf("SSH Agent does not contain any identities")
+		}
+
+		return signers, nil
 	}
 
 	keys, err := client.List()

--- a/host/signer.go
+++ b/host/signer.go
@@ -55,8 +55,8 @@ func AuthorizedKeys(file string) ([]ssh.PublicKey, error) {
 func Signers(privateKeys []string) ([]ssh.Signer, func(), error) {
 	var (
 		socket  = os.Getenv("SSH_AUTH_SOCK")
-		cleanup = func() {}
 		signers []ssh.Signer
+		cleanup func()
 		err     error
 	)
 

--- a/host/signer.go
+++ b/host/signer.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/owenthereal/upterm/utils"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 	"golang.org/x/crypto/ssh/terminal"
@@ -48,22 +49,32 @@ func AuthorizedKeys(file string) ([]ssh.PublicKey, error) {
 	return authorizedKeys, nil
 }
 
+// Signers return signers based on the folllowing conditions:
+// If private key is not supplied, it returns signers from SSH agent; If SSH agent returns no signer, it generates a private key and returns the corresponding signer.
+// If private key is supplied, it returns signers from SSH agent with matching private keys and adds priavte keys to SSH agent where possible; If there is an error, it falls back to return signers from files
 func Signers(privateKeys []string) ([]ssh.Signer, func(), error) {
-	socket := os.Getenv("SSH_AUTH_SOCK")
-	cleanup := func() {}
+	var (
+		socket  = os.Getenv("SSH_AUTH_SOCK")
+		cleanup = func() {}
+		signers []ssh.Signer
+		err     error
+	)
 
-	if socket == "" {
-		signers, err := SignersFromFiles(privateKeys)
+	if len(privateKeys) == 0 {
+		signers, cleanup, err = SignersFromSSHAgent(socket)
+		if err != nil {
+			signers, err = utils.CreateSigners(nil)
+		}
+
 		return signers, cleanup, err
 	}
 
-	signers, cleanup, err := SignersFromSSHAgent(socket, privateKeys)
+	signers, cleanup, err = SignersFromSSHAgentForKeys(socket, privateKeys)
 	if err != nil {
 		signers, err = SignersFromFiles(privateKeys)
-		return signers, cleanup, err
 	}
 
-	return signers, cleanup, nil
+	return signers, cleanup, err
 }
 
 func SignersFromFiles(privateKeys []string) ([]ssh.Signer, error) {
@@ -78,8 +89,18 @@ func SignersFromFiles(privateKeys []string) ([]ssh.Signer, error) {
 	return signers, nil
 }
 
-func SignersFromSSHAgent(socket string, privateKeys []string) ([]ssh.Signer, func(), error) {
+// SignersFromSSHAgent returns all signers from SSH agent
+func SignersFromSSHAgent(socket string) ([]ssh.Signer, func(), error) {
+	return SignersFromSSHAgentForKeys(socket, nil)
+}
+
+// SignersFromSSHAgentForKeys retruns signers from SSH agent for matching private keys.
+// It also adds private key to SSH agent where possbile which simulates the behavior of ssh
+func SignersFromSSHAgentForKeys(socket string, privateKeys []string) ([]ssh.Signer, func(), error) {
 	cleanup := func() {}
+	if socket == "" {
+		return nil, cleanup, fmt.Errorf("SSH Agent is not running")
+	}
 
 	conn, err := net.Dial("unix", socket)
 	if err != nil {
@@ -87,12 +108,17 @@ func SignersFromSSHAgent(socket string, privateKeys []string) ([]ssh.Signer, fun
 	}
 
 	cleanup = func() { conn.Close() }
-	signers, err := signersFromSSHAgent(agent.NewClient(conn), privateKeys, promptForPassphrase)
+	signers, err := signersFromSSHAgentForKeys(agent.NewClient(conn), privateKeys, promptForPassphrase)
 
 	return signers, cleanup, err
 }
 
-func signersFromSSHAgent(client agent.Agent, privateKeys []string, promptForPassphrase func(file string) ([]byte, error)) ([]ssh.Signer, error) {
+func signersFromSSHAgentForKeys(client agent.Agent, privateKeys []string, promptForPassphrase func(file string) ([]byte, error)) ([]ssh.Signer, error) {
+	// Return all signers from SSH agent if no private key is specified
+	if len(privateKeys) == 0 {
+		return client.Signers()
+	}
+
 	keys, err := client.List()
 	if err != nil {
 		return nil, err
@@ -131,7 +157,7 @@ func signersFromSSHAgent(client agent.Agent, privateKeys []string, promptForPass
 		return nil, err
 	}
 
-	return signersFromSSHAgent(client, privateKeys, promptForPassphrase)
+	return signersFromSSHAgentForKeys(client, privateKeys, promptForPassphrase)
 }
 
 func addPrivateKeysToAgent(client agent.Agent, privateKeys []string, promptForPassphrase func(file string) ([]byte, error)) error {

--- a/host/signer_test.go
+++ b/host/signer_test.go
@@ -123,6 +123,7 @@ func Test_signersFromSSHAgentForKeys(t *testing.T) {
 		{
 			name:        "no private key",
 			signerCount: 0,
+			errMsg:      "SSH Agent does not contain any identities",
 		},
 	}
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -77,14 +77,12 @@ func CreateSigners(privateKeys [][]byte) ([]ssh.Signer, error) {
 			return nil, err
 		}
 
-		for _, pk := range []interface{}{epk} {
-			signer, err := ssh.NewSignerFromKey(pk)
-			if err != nil {
-				return nil, err
-			}
-
-			signers = append(signers, signer)
+		signer, err := ssh.NewSignerFromKey(epk)
+		if err != nil {
+			return nil, err
 		}
+
+		signers = append(signers, signer)
 
 	}
 


### PR DESCRIPTION
Mark private key optional for `upterm host`.
Private key is first read from SSH Agent if no private key file is specified.
When there is not private key from SSH Agent or a file, a private key is generated.

Fixes https://github.com/owenthereal/upterm/issues/73.