### PR TITLE
Update a fork of x/crypto with RFC8308 support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -89,5 +89,5 @@ require (
 
 replace (
 	github.com/gliderlabs/ssh => github.com/owenthereal/ssh v0.2.3-0.20220217224334-0f0fc8cdc7dd
-	golang.org/x/crypto => github.com/owenthereal/upterm.crypto v0.0.0-20220218223420-70bd1ccad47a
+	golang.org/x/crypto => github.com/owenthereal/upterm.crypto v0.0.0-20220305194929-d2a67c5c7b65
 )

--- a/go.sum
+++ b/go.sum
@@ -182,8 +182,8 @@ github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/owenthereal/ssh v0.2.3-0.20220217224334-0f0fc8cdc7dd h1:pjW2LP+jjDUcNb0NthjmqVLJcpJYO2/Rcfz97r9tnMQ=
 github.com/owenthereal/ssh v0.2.3-0.20220217224334-0f0fc8cdc7dd/go.mod h1:ZSS+CUoKHDrqVakTfTWUlKSr9MtMFkC4UvtQKD7O914=
-github.com/owenthereal/upterm.crypto v0.0.0-20220218223420-70bd1ccad47a h1:wtKNMps4qZ0lOpb2yuwozPA50exN4m9tuuhRi/EAkYc=
-github.com/owenthereal/upterm.crypto v0.0.0-20220218223420-70bd1ccad47a/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+github.com/owenthereal/upterm.crypto v0.0.0-20220305194929-d2a67c5c7b65 h1:8ZEz/HNp0iYbIH/r7LCpTbdVWHNoWwe9gMWNOvgb/lk=
+github.com/owenthereal/upterm.crypto v0.0.0-20220305194929-d2a67c5c7b65/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 github.com/pborman/ansi v0.0.0-20160920233902-86f499584b0a h1:Yw/M+CoU75So9ZUQpRGOdwWvS9fHKSmhT+e+np+oF90=
 github.com/pborman/ansi v0.0.0-20160920233902-86f499584b0a/go.mod h1:SgWzwMAx1X/Ez7i90VqF8LRiQtx52pWDiQP+x3iGnzw=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/vendor/golang.org/x/crypto/ssh/messages.go
+++ b/vendor/golang.org/x/crypto/ssh/messages.go
@@ -141,6 +141,16 @@ type serviceAcceptMsg struct {
 	Service string `sshtype:"6"`
 }
 
+// See RFC 4253, section 10.
+const msgExtInfo = 7
+
+// See RFC 8308, section 2.3.
+type extInfoMsg struct {
+	NumExtensions uint32 `sshtype:"7"`
+	Extension     string
+	Algorithms    []string
+}
+
 // See RFC 4252, section 5.
 const msgUserAuthRequest = 50
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -235,7 +235,7 @@ github.com/ulikunitz/xz
 github.com/ulikunitz/xz/internal/hash
 github.com/ulikunitz/xz/internal/xlog
 github.com/ulikunitz/xz/lzma
-# golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e => github.com/owenthereal/upterm.crypto v0.0.0-20220218223420-70bd1ccad47a
+# golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e => github.com/owenthereal/upterm.crypto v0.0.0-20220305194929-d2a67c5c7b65
 ## explicit; go 1.17
 golang.org/x/crypto/blowfish
 golang.org/x/crypto/chacha20
@@ -354,4 +354,4 @@ google.golang.org/protobuf/types/known/timestamppb
 ## explicit; go 1.15
 gopkg.in/yaml.v2
 # github.com/gliderlabs/ssh => github.com/owenthereal/ssh v0.2.3-0.20220217224334-0f0fc8cdc7dd
-# golang.org/x/crypto => github.com/owenthereal/upterm.crypto v0.0.0-20220218223420-70bd1ccad47a
+# golang.org/x/crypto => github.com/owenthereal/upterm.crypto v0.0.0-20220305194929-d2a67c5c7b65


### PR DESCRIPTION
This adds signature algorithms are preffered order to be used for "publickey" auth.
It prefers ED25519 over RSA if clients have the keys.

See
https://github.com/owenthereal/upterm.crypto/commit/d2a67c5c7b65d18c49fed59726a82c6e9bd32192.