### PR TITLE
Do not automatically add keys to SSH agent

### DIFF
--- a/host/signer.go
+++ b/host/signer.go
@@ -50,7 +50,7 @@ func AuthorizedKeys(file string) ([]ssh.PublicKey, error) {
 }
 
 // Signers return signers based on the folllowing conditions:
-// If ssh agent is running and has keys, it returns signers from SSH agent, otherwise return signers from private keys;
+// If SSH agent is running and has keys, it returns signers from SSH agent, otherwise return signers from private keys;
 // If neither works, it generates a signer on the fly.
 func Signers(privateKeys []string) ([]ssh.Signer, func(), error) {
 	var (
@@ -144,25 +144,6 @@ func readPrivateKeyFromFile(file string, promptForPassphrase func(file string) (
 	}
 
 	return nil, &errDescryptingPrivateKey{file}
-}
-
-func readPublicKeysBestEfforts(privateKeys []string) []ssh.PublicKey {
-	var pks []ssh.PublicKey
-	for _, file := range privateKeys {
-		pb, err := ioutil.ReadFile(file + ".pub")
-		if err != nil {
-			continue
-		}
-
-		pk, _, _, _, err := ssh.ParseAuthorizedKey(pb)
-		if err != nil {
-			continue
-		}
-
-		pks = append(pks, pk)
-	}
-
-	return pks
 }
 
 func promptForPassphrase(file string) ([]byte, error) {

--- a/host/signer.go
+++ b/host/signer.go
@@ -50,28 +50,22 @@ func AuthorizedKeys(file string) ([]ssh.PublicKey, error) {
 }
 
 // Signers return signers based on the folllowing conditions:
-// If private key is not supplied, it returns signers from SSH agent; If SSH agent returns no signer, it generates a private key and returns the corresponding signer.
-// If private key is supplied, it returns signers from SSH agent with matching private keys and adds priavte keys to SSH agent where possible; If there is an error, it falls back to return signers from files
+// If ssh agent is running and has keys, it returns signers from SSH agent, otherwise return signers from private keys;
+// If neither works, it generates a signer on the fly.
 func Signers(privateKeys []string) ([]ssh.Signer, func(), error) {
 	var (
-		socket  = os.Getenv("SSH_AUTH_SOCK")
 		signers []ssh.Signer
 		cleanup func()
 		err     error
 	)
 
-	if len(privateKeys) == 0 {
-		signers, cleanup, err = SignersFromSSHAgent(socket)
-		if err != nil {
-			signers, err = utils.CreateSigners(nil)
-		}
-
-		return signers, cleanup, err
+	signers, cleanup, err = signersFromSSHAgent(os.Getenv("SSH_AUTH_SOCK"))
+	if len(signers) == 0 || err != nil {
+		signers, err = SignersFromFiles(privateKeys)
 	}
 
-	signers, cleanup, err = SignersFromSSHAgentForKeys(socket, privateKeys)
 	if err != nil {
-		signers, err = SignersFromFiles(privateKeys)
+		signers, err = utils.CreateSigners(nil)
 	}
 
 	return signers, cleanup, err
@@ -89,14 +83,7 @@ func SignersFromFiles(privateKeys []string) ([]ssh.Signer, error) {
 	return signers, nil
 }
 
-// SignersFromSSHAgent returns all signers from SSH agent
-func SignersFromSSHAgent(socket string) ([]ssh.Signer, func(), error) {
-	return SignersFromSSHAgentForKeys(socket, nil)
-}
-
-// SignersFromSSHAgentForKeys retruns signers from SSH agent for matching private keys.
-// It also adds private key to SSH agent where possbile which simulates the behavior of ssh
-func SignersFromSSHAgentForKeys(socket string, privateKeys []string) ([]ssh.Signer, func(), error) {
+func signersFromSSHAgent(socket string) ([]ssh.Signer, func(), error) {
 	cleanup := func() {}
 	if socket == "" {
 		return nil, cleanup, fmt.Errorf("SSH Agent is not running")
@@ -106,84 +93,12 @@ func SignersFromSSHAgentForKeys(socket string, privateKeys []string) ([]ssh.Sign
 	if err != nil {
 		return nil, cleanup, err
 	}
-
 	cleanup = func() { conn.Close() }
-	signers, err := signersFromSSHAgentForKeys(agent.NewClient(conn), privateKeys, promptForPassphrase)
+
+	client := agent.NewClient(conn)
+	signers, err := client.Signers()
 
 	return signers, cleanup, err
-}
-
-func signersFromSSHAgentForKeys(client agent.Agent, privateKeys []string, promptForPassphrase func(file string) ([]byte, error)) ([]ssh.Signer, error) {
-	// Return all signers from SSH agent if no private key is specified
-	if len(privateKeys) == 0 {
-		signers, err := client.Signers()
-		if err != nil {
-			return nil, err
-		}
-
-		if len(signers) == 0 {
-			return nil, fmt.Errorf("SSH Agent does not contain any identities")
-		}
-
-		return signers, nil
-	}
-
-	keys, err := client.List()
-	if err != nil {
-		return nil, err
-	}
-	publicKeys := readPublicKeysBestEfforts(privateKeys)
-
-	var agentKeysIdx []int
-	for i, key := range keys {
-		for _, pk := range publicKeys {
-			if bytes.Equal(key.Blob, pk.Marshal()) {
-				agentKeysIdx = append(agentKeysIdx, i)
-			}
-		}
-	}
-
-	if len(agentKeysIdx) > 0 {
-		signers, err := client.Signers()
-		if err != nil {
-			return nil, err
-		}
-
-		var matchedSigners []ssh.Signer
-		for _, idx := range agentKeysIdx {
-			matchedSigners = append(matchedSigners, signers[idx])
-		}
-
-		if len(matchedSigners) == 0 {
-			return nil, fmt.Errorf("No matching signers from SSH agent")
-		}
-
-		return matchedSigners, nil
-	}
-
-	// Add key if there is no match keys
-	if err := addPrivateKeysToAgent(client, privateKeys, promptForPassphrase); err != nil {
-		return nil, err
-	}
-
-	return signersFromSSHAgentForKeys(client, privateKeys, promptForPassphrase)
-}
-
-func addPrivateKeysToAgent(client agent.Agent, privateKeys []string, promptForPassphrase func(file string) ([]byte, error)) error {
-	for _, pk := range privateKeys {
-		key, err := readPrivateKeyFromFile(pk, promptForPassphrase)
-		if err != nil {
-			return err
-		}
-
-		if err := client.Add(agent.AddedKey{
-			PrivateKey: key,
-		}); err != nil {
-			return err
-		}
-	}
-
-	return nil
 }
 
 func signerFromFile(file string, promptForPassphrase func(file string) ([]byte, error)) (ssh.Signer, error) {

--- a/host/signer_test.go
+++ b/host/signer_test.go
@@ -62,6 +62,7 @@ XBcvbGIDxNBoIlPFRM+bqvIDC1sQi3MIh3l/NZQxxIkW/+I4uClYpmNGXPZaNZNhpdv1PJ
 a9rQ==
 -----END OPENSSH PRIVATE KEY-----
 `
+	// nolint
 	rsaPublicKey = `ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCt//y3H4heRi1+3bO+FsqKyGTw5YQnu6MChEaDJY2SJqFCHGEwBAWGsuaDZPb6P+V16I5u2H+MtKBWDbkVK9760DkAFimuQ4XTtIzPhyb+Jc95wvNW6pAYXoetVlZIbzNzMEykE41kOMq19SNS3snvE5mYzfd2B6AGw3T2SubfF6G0staxtEYwlsWP/N+YIR4yLz11bxwuuTee/eMldvKZfzQQXIuopANU2mnAmoOqsG0G+DKNuXw7F7zd7lxus8zBF3fszur7Sc9APbWab5phJXWzE81ME2Z0Rro3/l/5mD3YqmS6+jyIqlvqR150Uf/2rKawVgzxZWvQhe1+gGIktavL85dO9VnxA/BASYM0caqFY/KwVpAs/mZ18SpjgPaEzm3H5eeTJRFMrwRusyunPTDv8lmAAXsr/ZMhd1gBkDiGE/YuTfekv8rMbkZNeB2HuXavcRTuCqY8y44ehe+sRug9nwykPnfRqjIeAm9zh+zknfJGl5TONHKnEj5tudpUvTd38ZnOM+CTzMHbSDOwkSLAp9mCzrbWc6OIeVqsqibPmia4SxyP7wxnszfH1MOkuCmphiCzk4nicYDhMW6jjXhRKok4yNIU9wqj0MMEKS3RKblAzCu7VFVTDrLSJIzs7Ch0RIuGnVTQ5S4O156Kr9hL535k6c6/NUXbylXtuw==`
 
 	// Passphrase is "1234"
@@ -74,6 +75,7 @@ sSq5R8Qu+iqFOtgNFnPI1/wu22agUYxs3h6Su4Jv6WbySJpJhHhIN/6pZ4DZgj4zWGGSJl
 CUI+b0Gxfqa/HSKlS23Iu7ZeWoMakwvcg5A5M8E/ihBLSDNsCJU8pgZ9FD
 -----END OPENSSH PRIVATE KEY-----
 `
+	// nolint
 	ed25519PublicKey = `ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA9dIfLyILssYzKIVY7UQenn2Il6cUeeYppVwDSAiqPz jou@oou-ltm.internal.salesforce.com`
 )
 


### PR DESCRIPTION
Do not automatically add keys to SSH agent for `upterm host`. This should be the job of
`ssh-add`.