### PR TITLE
Add --github-user and --gitlab-user flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,14 @@ $ ssh TOKEN@uptermd.upterm.dev
 # Host a terminal session that only allows specified client public key(s) to connect
 $ upterm host --authorized-key PATH_TO_PUBLIC_KEY
 
+# Host a terminal session that only allows specified GitHub user client public key(s) to connect
+# This is compatible with --authorized-keys.
+$ upterm host --github-user username
+
+# Host a terminal session that only allows specified GitLab user client public key(s) to connect
+# This is compatible with --authorized-keys.
+$ upterm host --gitlab-user username
+
 # Host a session with a custom command
 $ upterm host -- docker run --rm -ti ubuntu bash
 

--- a/cmd/upterm/command/host.go
+++ b/cmd/upterm/command/host.go
@@ -27,8 +27,8 @@ var (
 	flagPrivateKeys        []string
 	flagKnownHostsFilename string
 	flagAuthorizedKeys     string
-	flagGitHubUser         string
-	flagGitLabUser         string
+	flagGitHubUsers        []string
+	flagGitLabUsers        []string
 	flagReadOnly           bool
 )
 
@@ -68,8 +68,8 @@ func hostCmd() *cobra.Command {
 	cmd.PersistentFlags().StringSliceVarP(&flagPrivateKeys, "private-key", "i", defaultPrivateKeys(homeDir), "private key file for public key authentication against the upterm server")
 	cmd.PersistentFlags().StringVarP(&flagKnownHostsFilename, "known-hosts", "", defaultKnownHost(homeDir), "a file contains the known keys for remote hosts (required).")
 	cmd.PersistentFlags().StringVarP(&flagAuthorizedKeys, "authorized-key", "a", "", "an authorized_keys file that lists public keys that are permitted to connect.")
-	cmd.PersistentFlags().StringVarP(&flagGitHubUser, "github-user", "", "", "this GitHub user public keys are permitted to connect.")
-	cmd.PersistentFlags().StringVarP(&flagGitLabUser, "gitlab-user", "", "", "this GitLab user public keys are permitted to connect.")
+	cmd.PersistentFlags().StringSliceVar(&flagGitHubUsers, "github-user", nil, "this GitHub user public keys are permitted to connect.")
+	cmd.PersistentFlags().StringSliceVar(&flagGitLabUsers, "gitlab-user", nil, "this GitLab user public keys are permitted to connect.")
 	cmd.PersistentFlags().BoolVarP(&flagReadOnly, "read-only", "r", false, "host a read-only session. Clients won't be able to interact.")
 
 	return cmd
@@ -141,15 +141,15 @@ func shareRunE(c *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("error reading authorized keys: %w", err)
 	}
-	if flagGitHubUser != "" {
-		gitHubUserKeys, err := host.GitHubUserKeys(flagGitHubUser)
+	if flagGitHubUsers != nil {
+		gitHubUserKeys, err := host.GitHubUserKeys(flagGitHubUsers)
 		if err != nil {
 			return fmt.Errorf("error reading GitHub user keys: %w", err)
 		}
 		authorizedKeys = append(authorizedKeys, gitHubUserKeys...)
 	}
-	if flagGitLabUser != "" {
-		gitLabUserKeys, err := host.GitLabUserKeys(flagGitLabUser)
+	if flagGitLabUsers != nil {
+		gitLabUserKeys, err := host.GitLabUserKeys(flagGitLabUsers)
 		if err != nil {
 			return fmt.Errorf("error reading GitLab user keys: %w", err)
 		}

--- a/cmd/upterm/command/host.go
+++ b/cmd/upterm/command/host.go
@@ -27,6 +27,8 @@ var (
 	flagPrivateKeys        []string
 	flagKnownHostsFilename string
 	flagAuthorizedKeys     string
+	flagGitHubUser         string
+	flagGitLabUser         string
 	flagReadOnly           bool
 )
 
@@ -66,6 +68,8 @@ func hostCmd() *cobra.Command {
 	cmd.PersistentFlags().StringSliceVarP(&flagPrivateKeys, "private-key", "i", defaultPrivateKeys(homeDir), "private key file for public key authentication against the upterm server")
 	cmd.PersistentFlags().StringVarP(&flagKnownHostsFilename, "known-hosts", "", defaultKnownHost(homeDir), "a file contains the known keys for remote hosts (required).")
 	cmd.PersistentFlags().StringVarP(&flagAuthorizedKeys, "authorized-key", "a", "", "an authorized_keys file that lists public keys that are permitted to connect.")
+	cmd.PersistentFlags().StringVarP(&flagGitHubUser, "github-user", "", "", "this GitHub user public keys are permitted to connect.")
+	cmd.PersistentFlags().StringVarP(&flagGitLabUser, "gitlab-user", "", "", "this GitLab user public keys are permitted to connect.")
 	cmd.PersistentFlags().BoolVarP(&flagReadOnly, "read-only", "r", false, "host a read-only session. Clients won't be able to interact.")
 
 	return cmd
@@ -136,6 +140,20 @@ func shareRunE(c *cobra.Command, args []string) error {
 	}
 	if err != nil {
 		return fmt.Errorf("error reading authorized keys: %w", err)
+	}
+	if flagGitHubUser != "" {
+		gitHubUserKeys, err := host.GitHubUserKeys(flagGitHubUser)
+		if err != nil {
+			return fmt.Errorf("error reading GitHub user keys: %w", err)
+		}
+		authorizedKeys = append(authorizedKeys, gitHubUserKeys...)
+	}
+	if flagGitLabUser != "" {
+		gitLabUserKeys, err := host.GitLabUserKeys(flagGitLabUser)
+		if err != nil {
+			return fmt.Errorf("error reading GitLab user keys: %w", err)
+		}
+		authorizedKeys = append(authorizedKeys, gitLabUserKeys...)
 	}
 
 	signers, cleanup, err := host.Signers(flagPrivateKeys)


### PR DESCRIPTION
This adds new flags to use a GitHub/GitLab's user public keys as
authorized keys. The keys are downloaded, processed and added to any
existing authorized keys provided by the --authorized-key flag.

This fixes #72.