### PR TITLE
feat: add interactive flag

### DIFF
--- a/cmd/upterm/command/host.go
+++ b/cmd/upterm/command/host.go
@@ -31,6 +31,7 @@ var (
 	flagGitLabUsers        []string
 	flagSourceHutUsers     []string
 	flagReadOnly           bool
+	flagInteractive        bool
 )
 
 func hostCmd() *cobra.Command {
@@ -72,6 +73,7 @@ func hostCmd() *cobra.Command {
 	cmd.PersistentFlags().StringSliceVar(&flagGitHubUsers, "github-user", nil, "this GitHub user public keys are permitted to connect.")
 	cmd.PersistentFlags().StringSliceVar(&flagGitLabUsers, "gitlab-user", nil, "this GitLab user public keys are permitted to connect.")
 	cmd.PersistentFlags().StringSliceVar(&flagSourceHutUsers, "srht-user", nil, "this SourceHut user public keys are permitted to connect.")
+	cmd.PersistentFlags().BoolVarP(&flagInteractive, "interactive", "", true, "directly launch the given command without accepting input from the user.")
 	cmd.PersistentFlags().BoolVarP(&flagReadOnly, "read-only", "r", false, "host a read-only session. Clients won't be able to interact.")
 
 	return cmd
@@ -224,20 +226,23 @@ func displaySessionCallback(session *api.GetSessionResponse) error {
 		return err
 	}
 
-	fmt.Printf("\nRun 'upterm session current' to display this screen again\n\n")
+	if flagInteractive {
 
-	if err := keyboard.Open(); err != nil {
-		return err
-	}
-	defer keyboard.Close()
+		fmt.Printf("\nRun 'upterm session current' to display this screen again\n\n")
 
-	fmt.Println("Press <q> or <ctrl-c> to accept connections...")
-	for {
-		char, key, err := keyboard.GetKey()
-		if err != nil {
+		if err := keyboard.Open(); err != nil {
 			return err
-		} else if key == keyboard.KeyCtrlC || char == 'q' {
-			break
+		}
+		defer keyboard.Close()
+
+		fmt.Println("Press <q> or <ctrl-c> to accept connections...")
+		for {
+			char, key, err := keyboard.GetKey()
+			if err != nil {
+				return err
+			} else if key == keyboard.KeyCtrlC || char == 'q' {
+				break
+			}
 		}
 	}
 


### PR DESCRIPTION
to run upterm host without the requrement to automatically accect connections, --interactive=false could be used as flag to skip the command prompt for actively confirming accepting new connections.

*WHY*:
As we are using `upterm` in combination with github actions to provide a reverse-shell to check failed actions we have to run `upterm host` without manual user interaction before. For that we've introduced the `--interactive` flag which we set to `false` in our use case.
We could also think about changing the flag name to `--auto-accept-connections` to make it more clear what the flag supposed to do.