### PR TITLE
Shrink uptermd Docker image by 5 MB, 20%

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+# Because changes to just the Dockerfile force a more or less total rebuild,
+# which doesn't need to be the case.
+Dockerfile.uptermd

--- a/Dockerfile.uptermd
+++ b/Dockerfile.uptermd
@@ -37,6 +37,8 @@ COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /etc/group /etc/group
 COPY --from=builder /build/uptermd .
 
+USER noroot:noroot
+
 # sshd
 EXPOSE 2222
 # ws

--- a/Dockerfile.uptermd
+++ b/Dockerfile.uptermd
@@ -1,23 +1,41 @@
-FROM golang:alpine as builder
+FROM golang:1.21 as builder
 
-WORKDIR $GOPATH/src/github.com/owenthereal/upterm
+RUN adduser \
+  --disabled-password \
+  --gecos "" \
+  --home "/nonexistent" \
+  --shell "/sbin/nologin" \
+  --no-create-home \
+  --uid 65532 \
+  noroot
+
+WORKDIR /build
+
+COPY go.mod .
+COPY go.sum .
+
+RUN go mod download
+RUN go mod verify
+
 COPY . .
 ENV CGO_ENABLED=0 GOOS=linux GOARCH=amd64
-RUN go install ./cmd/uptermd/...
+RUN go build -o uptermd ./cmd/uptermd
 
 # Prepare for image
-FROM alpine:latest
+FROM scratch
 
 MAINTAINER Owen Ou
 LABEL org.opencontainers.image.source https://github.com/owenthereal/upterm
 
-RUN adduser -D uptermd
-USER uptermd
 
 WORKDIR /app
 ENV PATH="/app:${PATH}"
 
-COPY --from=builder /go/bin/* /app
+COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder /etc/group /etc/group
+COPY --from=builder /build/uptermd .
 
 # sshd
 EXPOSE 2222


### PR DESCRIPTION
This PR bases the output Docker image on `SCRATCH` instead of alpine. Alpine is a great base, but for statically linked Go apps, we don't even need that.

I'm currently self-hosting using this updated image, it works identically as far as I can tell (e.g. no permission issues from the `noroot` user).

Sizes were calculated as:

```bash
# Build at current head
docker build -f Dockerfile.uptermd -t uptermd .
docker save uptermd -o uptermd.tar

# Checkout this PR
docker build -f Dockerfile.uptermd -t uptermd-new .
docker save uptermd-new -o uptermd-new.tar
```

`uptermd.tar` is ~26 MB, `uptermd-new.tar` is 21 MB.

The 5 MB isn't really _that_ important when the image is already only 26 MB (as compared to some enormous Docker image people sling around), but I figured, why not?