### PR TITLE
Revert "Shrink uptermd Docker image by 5 MB, 20% (#225)"

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,0 @@
-# Because changes to just the Dockerfile force a more or less total rebuild,
-# which doesn't need to be the case.
-Dockerfile.uptermd

--- a/Dockerfile.uptermd
+++ b/Dockerfile.uptermd
@@ -1,43 +1,23 @@
-FROM golang:1.21 as builder
+FROM golang:alpine as builder
 
-RUN adduser \
-  --disabled-password \
-  --gecos "" \
-  --home "/nonexistent" \
-  --shell "/sbin/nologin" \
-  --no-create-home \
-  --uid 65532 \
-  noroot
-
-WORKDIR /build
-
-COPY go.mod .
-COPY go.sum .
-
-RUN go mod download
-RUN go mod verify
-
+WORKDIR $GOPATH/src/github.com/owenthereal/upterm
 COPY . .
 ENV CGO_ENABLED=0 GOOS=linux GOARCH=amd64
-RUN go build -o uptermd ./cmd/uptermd
+RUN go install ./cmd/uptermd/...
 
 # Prepare for image
-FROM scratch
+FROM alpine:latest
 
 MAINTAINER Owen Ou
 LABEL org.opencontainers.image.source https://github.com/owenthereal/upterm
 
+RUN adduser -D uptermd
+USER uptermd
 
 WORKDIR /app
 ENV PATH="/app:${PATH}"
 
-COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder /etc/group /etc/group
-COPY --from=builder /build/uptermd .
-
-USER noroot:noroot
+COPY --from=builder /go/bin/* /app
 
 # sshd
 EXPOSE 2222


### PR DESCRIPTION
This reverts commit bb763d6cdd9e5b1da00ffe794c71b3dfe0422828.

@bcspragu I have to revert https://github.com/owenthereal/upterm/pull/225 because the production community server shares the same image and needs `sh` to compute fly.io node address at boot time: https://github.com/owenthereal/upterm/blob/2e48f7341cf51a291bb626ddfc70ae56da0b49d0/fly.toml#L11-L12. I think we might have to stick with the Alpine image or if you have a suggestion that a smaller image that has a shell in it.