### PR TITLE
Codeberg user authorized key support

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,10 @@ Host a session with specified client public key(s) authorized to connect:
 upterm host --authorized-key PATH_TO_PUBLIC_KEY
 ```
 
-Authorize specified GitHub, GitLab, or SourceHut users with their corresponding public keys:
+Authorize specified Codeberg, GitHub, GitLab, or SourceHut users with their corresponding public keys:
 
 ```console
+upterm host --codeberg-user username
 upterm host --github-user username
 upterm host --gitlab-user username
 upterm host --srht-user username

--- a/cmd/upterm/command/host.go
+++ b/cmd/upterm/command/host.go
@@ -26,6 +26,7 @@ var (
 	flagPrivateKeys        []string
 	flagKnownHostsFilename string
 	flagAuthorizedKeys     string
+	flagCodebergUsers      []string
 	flagGitHubUsers        []string
 	flagGitLabUsers        []string
 	flagSourceHutUsers     []string
@@ -73,6 +74,7 @@ private key. To authorize client connections, specify a authorized_key file with
 	cmd.PersistentFlags().StringSliceVarP(&flagPrivateKeys, "private-key", "i", defaultPrivateKeys(homeDir), "Specify private key files for public key authentication with the upterm server (required).")
 	cmd.PersistentFlags().StringVarP(&flagKnownHostsFilename, "known-hosts", "", defaultKnownHost(homeDir), "Specify a file containing known keys for remote hosts (required).")
 	cmd.PersistentFlags().StringVar(&flagAuthorizedKeys, "authorized-keys", "", "Specify a authorize_keys file listing authorized public keys for connection.")
+	cmd.PersistentFlags().StringSliceVar(&flagCodebergUsers, "codeberg-user", nil, "Authorize specified Codeberg users by allowing their public keys to connect.")
 	cmd.PersistentFlags().StringSliceVar(&flagGitHubUsers, "github-user", nil, "Authorize specified GitHub users by allowing their public keys to connect. Configure GitHub CLI environment variables as needed; see https://cli.github.com/manual/gh_help_environment for details.")
 	cmd.PersistentFlags().StringSliceVar(&flagGitLabUsers, "gitlab-user", nil, "Authorize specified GitLab users by allowing their public keys to connect.")
 	cmd.PersistentFlags().StringSliceVar(&flagSourceHutUsers, "srht-user", nil, "Authorize specified SourceHut users by allowing their public keys to connect.")
@@ -157,6 +159,13 @@ func shareRunE(c *cobra.Command, args []string) error {
 			return fmt.Errorf("error reading authorized keys: %w", err)
 		}
 		authorizedKeys = append(authorizedKeys, aks)
+	}
+	if flagCodebergUsers != nil {
+		codebergUserKeys, err := host.CodebergUserAuthorizedKeys(flagCodebergUsers)
+		if err != nil {
+			return fmt.Errorf("error reading Codeberg user keys: %w", err)
+		}
+		authorizedKeys = append(authorizedKeys, codebergUserKeys...)
 	}
 	if flagGitHubUsers != nil {
 		gitHubUserKeys, err := host.GitHubUserAuthorizedKeys(flagGitHubUsers, logger)

--- a/docs/upterm_host.md
+++ b/docs/upterm_host.md
@@ -41,6 +41,7 @@ upterm host [flags]
 ```
       --accept                   Automatically accept client connections without prompts.
       --authorized-keys string   Specify a authorize_keys file listing authorized public keys for connection.
+      --codeberg-user strings    Authorize specified Codeberg users by allowing their public keys to connect.
   -f, --force-command string     Enforce a specified command for clients to join, and link the command's input/output to the client's terminal.
       --github-user strings      Authorize specified GitHub users by allowing their public keys to connect. Configure GitHub CLI environment variables as needed; see https://cli.github.com/manual/gh_help_environment for details.
       --gitlab-user strings      Authorize specified GitLab users by allowing their public keys to connect.

--- a/etc/completion/upterm.bash_completion.sh
+++ b/etc/completion/upterm.bash_completion.sh
@@ -397,6 +397,8 @@ _upterm_host()
 
     flags+=("--accept")
     flags+=("--authorized-keys=")
+    flags+=("--codeberg-user=")
+    two_word_flags+=("--codeberg-user")
     two_word_flags+=("--authorized-keys")
     flags+=("--force-command=")
     two_word_flags+=("--force-command")

--- a/etc/man/man1/upterm-host.1
+++ b/etc/man/man1/upterm-host.1
@@ -30,6 +30,10 @@ private key. To authorize client connections, specify a authorized_key file with
 	Specify a authorize_keys file listing authorized public keys for connection.
 
 .PP
+\fB--codeberg-user\fP=[]
+	Authorize specified Codeberg users by allowing their public keys to connect.
+
+.PP
 \fB-f\fP, \fB--force-command\fP=""
 	Enforce a specified command for clients to join, and link the command's input/output to the client's terminal.
 

--- a/host/authorizedkeys.go
+++ b/host/authorizedkeys.go
@@ -15,6 +15,7 @@ import (
 )
 
 const (
+	codebergKeysUrlFmt  = "https://codeberg.org/%s"
 	gitHubKeysUrlFmt    = "https://github.com/%s"
 	gitLabKeysUrlFmt    = "https://gitlab.com/%s"
 	sourceHutKeysUrlFmt = "https://meta.sr.ht/~%s"
@@ -32,6 +33,10 @@ func AuthorizedKeysFromFile(file string) (*AuthorizedKey, error) {
 	}
 
 	return parseAuthorizedKeys(authorizedKeysBytes, file)
+}
+
+func CodebergUserAuthorizedKeys(usernames []string) ([]*AuthorizedKey, error) {
+	return usersPublicKeys(codebergKeysUrlFmt, usernames)
 }
 
 func GitHubUserAuthorizedKeys(usernames []string, logger *logrus.Logger) ([]*AuthorizedKey, error) {


### PR DESCRIPTION
A German non-profit hosts [Codeberg](https://codeberg.org), a popular, free Forgejo instance for a Git code forge with public keys from users.