### PR TITLE
Don't override Dockerfile entrypoint with `uptermd-fly`

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -37,6 +37,7 @@ jobs:
           pull: true
           file: Dockerfile.uptermd
           tags: ${{ steps.meta.outputs.tags }}
+          platforms: amd64,arm64
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: |
             type=gha

--- a/Dockerfile.uptermd
+++ b/Dockerfile.uptermd
@@ -12,6 +12,16 @@ RUN --mount=target=. \
     GOOS=$TARGETOS GOARCH=$TARGETARCH go install \
     ./cmd/...
 
+# For fly deployment only
+FROM gcr.io/distroless/static as uptermd-fly
+
+USER nonroot:nonroot
+
+WORKDIR /app
+ENV PATH="/app:${PATH}"
+
+COPY --from=builder /go/bin/uptermd /go/bin/uptermd-fly /app/
+
 FROM gcr.io/distroless/static
 
 USER nonroot:nonroot
@@ -29,14 +39,3 @@ EXPOSE 8080
 EXPOSE 9090
 
 ENTRYPOINT ["uptermd"]
-
-FROM gcr.io/distroless/static as uptermd-fly
-
-USER nonroot:nonroot
-
-WORKDIR /app
-ENV PATH="/app:${PATH}"
-
-COPY --from=builder /go/bin/uptermd /go/bin/uptermd-fly /app/
-
-ENTRYPOINT ["uptermd-fly"]

--- a/fly.toml
+++ b/fly.toml
@@ -6,6 +6,9 @@ kill_timeout = "5s"
 dockerfile = "Dockerfile.uptermd"
 build-target = "uptermd-fly"
 
+[experimental]
+entrypoint = ["uptermd-fly"]
+
 [[services]]
 protocol = "tcp"
 internal_port = 2222


### PR DESCRIPTION
https://github.com/owenthereal/upterm/pull/261 uses minimum image, but it overrides entrypoint with `uptrend-fly.`

This fixes https://github.com/owenthereal/upterm/issues/262.