### PR TITLE
Add support for authorizing connections based on public key

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,32 @@ networks:
 
 For more details on Traefik TCP and HTTP routing, see the [Traefik documentation](https://doc.traefik.io/traefik/routing/overview/).
 
+### Restricting Host Registration
+
+By default, any SSH client that can reach `uptermd` can register a session as a host.
+For private or invite-only deployments, the `--authorized-keys` flag (or `UPTERMD_AUTHORIZED_KEYS` environment variable) restricts host registration to a specific set of public keys.
+This mirrors OpenSSH's [`AuthorizedKeysFile`](https://man.openbsd.org/sshd_config#AuthorizedKeysFile) directive.
+
+```console
+uptermd --authorized-keys /etc/uptermd/authorized_keys
+```
+
+The flag accepts standard `authorized_keys`-formatted files (one key per line, comments allowed) and may be repeated to compose keys from multiple sources:
+
+```console
+uptermd --authorized-keys /etc/uptermd/team.keys --authorized-keys /etc/uptermd/ops.keys
+```
+
+Files are read once at startup; restart `uptermd` to pick up edits. Joiners (clients connecting to a session) are unaffected — they continue to be authorized by the host's own `authorized_keys`.
+
+For the Helm chart, populate the `authorized_keys` value:
+
+```yaml
+authorized_keys:
+  - "ssh-ed25519 AAAA... alice@laptop"
+  - "ssh-ed25519 BBBB... bob@desktop"
+```
+
 ## :chart_with_upwards_trend: Monitoring
 
 `uptermd` exposes Prometheus metrics at the `/metrics` endpoint when configured with `--metric-addr` (or `UPTERMD_METRIC_ADDR` environment variable).

--- a/charts/uptermd/templates/configmap.yaml
+++ b/charts/uptermd/templates/configmap.yaml
@@ -1,0 +1,13 @@
+{{- if gt (len .Values.authorized_keys) 0 }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "upterm.fullname" . }}
+  labels:
+    {{- include "upterm.labels" . | nindent 4 }}
+data:
+  authorized_keys: |-
+    {{- range .Values.authorized_keys }}
+    {{- . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/uptermd/templates/deployment.yaml
+++ b/charts/uptermd/templates/deployment.yaml
@@ -40,6 +40,10 @@ spec:
             - --ws-addr
             - $(POD_IP):80
             {{- end }}
+            {{- if gt (len .Values.authorized_keys) 0 }}
+            - --authorized-keys
+            - /etc/uptermd/authorized_keys
+            {{- end }}
             - --node-addr
             - $(POD_IP):22
             - --hostname
@@ -85,11 +89,20 @@ spec:
           volumeMounts:
             - mountPath: /host-keys
               name: host-keys
+            {{- if gt (len .Values.authorized_keys) 0 }}
+            - mountPath: /etc/uptermd
+              name: authorized-keys
+            {{- end }}
       volumes:
         - name: host-keys
           secret:
             secretName: {{ include "upterm.fullname" . }}
             defaultMode: 0600
+        {{- if gt (len .Values.authorized_keys) 0 }}
+        - name: authorized-keys
+          configMap:
+            name: uptermd
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/uptermd/templates/deployment.yaml
+++ b/charts/uptermd/templates/deployment.yaml
@@ -101,7 +101,7 @@ spec:
         {{- if gt (len .Values.authorized_keys) 0 }}
         - name: authorized-keys
           configMap:
-            name: uptermd
+            name: {{ include "upterm.fullname" . }}
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/uptermd/values.yaml
+++ b/charts/uptermd/values.yaml
@@ -67,6 +67,13 @@ affinity: {}
 
 host_keys: {}
 
+# SSH public keys (in `authorized_keys` line format, one entry per list item)
+# permitted to register as hosts on this uptermd. When empty, any client may
+# register. Edits require restarting uptermd to take effect.
+# Example:
+#   authorized_keys:
+#     - "ssh-ed25519 AAAA... alice@laptop"
+#     - "ssh-ed25519 BBBB... bob@desktop"
 authorized_keys: []
 
 hostname: my-upterm-host

--- a/charts/uptermd/values.yaml
+++ b/charts/uptermd/values.yaml
@@ -67,6 +67,8 @@ affinity: {}
 
 host_keys: {}
 
+authorized_keys: []
+
 hostname: my-upterm-host
 
 # Require ingress-nginx & cert-manager

--- a/cmd/uptermd/command/root.go
+++ b/cmd/uptermd/command/root.go
@@ -28,7 +28,7 @@ func Root() *cobra.Command {
 	cmd.PersistentFlags().StringP("ssh-addr", "", utils.DefaultLocalhost("2222"), "ssh server address")
 	cmd.PersistentFlags().StringP("ws-addr", "", "", "websocket server address")
 	cmd.PersistentFlags().StringP("node-addr", "", "", "node address")
-	cmd.PersistentFlags().StringP("authorized-keys", "", "", "authorized_keys file to control proxy access")
+	cmd.PersistentFlags().StringSliceP("authorized-keys", "", nil, "authorized_keys file(s) controlling which public keys may register as hosts; may be repeated, mirroring OpenSSH's AuthorizedKeysFile directive")
 	cmd.PersistentFlags().StringSliceP("private-key", "", nil, "server private key")
 	cmd.PersistentFlags().StringSliceP("hostname", "", nil, "server hostname for public-key authentication certificate principals. If empty, public-key authentication is used instead.")
 	cmd.PersistentFlags().BoolP("ssh-proxy-protocol", "", false, "enable PROXY protocol support for the SSH listener (for use behind TCP proxies like Traefik, HAProxy, or AWS ELB)")

--- a/cmd/uptermd/command/root.go
+++ b/cmd/uptermd/command/root.go
@@ -28,6 +28,7 @@ func Root() *cobra.Command {
 	cmd.PersistentFlags().StringP("ssh-addr", "", utils.DefaultLocalhost("2222"), "ssh server address")
 	cmd.PersistentFlags().StringP("ws-addr", "", "", "websocket server address")
 	cmd.PersistentFlags().StringP("node-addr", "", "", "node address")
+	cmd.PersistentFlags().StringP("authorized-keys", "", "", "authorized_keys file to control proxy access")
 	cmd.PersistentFlags().StringSliceP("private-key", "", nil, "server private key")
 	cmd.PersistentFlags().StringSliceP("hostname", "", nil, "server hostname for public-key authentication certificate principals. If empty, public-key authentication is used instead.")
 	cmd.PersistentFlags().BoolP("ssh-proxy-protocol", "", false, "enable PROXY protocol support for the SSH listener (for use behind TCP proxies like Traefik, HAProxy, or AWS ELB)")

--- a/server/server.go
+++ b/server/server.go
@@ -30,20 +30,21 @@ const (
 )
 
 type Opt struct {
-	SSHAddr          string       `mapstructure:"ssh-addr"`
-	SSHProxyProtocol bool         `mapstructure:"ssh-proxy-protocol"`
-	WSAddr           string       `mapstructure:"ws-addr"`
-	NodeAddr         string       `mapstructure:"node-addr"`
-	PrivateKeys      []string     `mapstructure:"private-key"`
-	Hostnames        []string     `mapstructure:"hostname"`
-	Network          string       `mapstructure:"network"`
-	NetworkOpts      []string     `mapstructure:"network-opt"`
-	MetricAddr       string       `mapstructure:"metric-addr"`
-	Debug            bool         `mapstructure:"debug"`
-	Routing          routing.Mode `mapstructure:"routing"`
-	ConsulURL        string       `mapstructure:"consul-url"`
-	ConsulSessionTTL string       `mapstructure:"consul-session-ttl"`
-	SentryDSN        string       `mapstructure:"sentry-dsn"`
+	SSHAddr            string       `mapstructure:"ssh-addr"`
+	SSHProxyProtocol   bool         `mapstructure:"ssh-proxy-protocol"`
+	WSAddr             string       `mapstructure:"ws-addr"`
+	NodeAddr           string       `mapstructure:"node-addr"`
+	AuthorizedKeysFile string       `mapstructure:"authorized-keys"`
+	PrivateKeys        []string     `mapstructure:"private-key"`
+	Hostnames          []string     `mapstructure:"hostname"`
+	Network            string       `mapstructure:"network"`
+	NetworkOpts        []string     `mapstructure:"network-opt"`
+	MetricAddr         string       `mapstructure:"metric-addr"`
+	Debug              bool         `mapstructure:"debug"`
+	Routing            routing.Mode `mapstructure:"routing"`
+	ConsulURL          string       `mapstructure:"consul-url"`
+	ConsulSessionTTL   string       `mapstructure:"consul-session-ttl"`
+	SentryDSN          string       `mapstructure:"sentry-dsn"`
 }
 
 // Validate validates the server configuration
@@ -240,13 +241,14 @@ func Start(ctx context.Context, opt Opt, logger *slog.Logger) error {
 		}
 
 		s := &Server{
-			NodeAddr:        nodeAddr,
-			HostSigners:     hostSigners,
-			Signers:         signers,
-			NetworkProvider: network,
-			SessionManager:  sessionManager,
-			Logger:          logger.With("component", "server"),
-			MetricsProvider: mp,
+			NodeAddr:           nodeAddr,
+			AuthorizedKeysFile: opt.AuthorizedKeysFile,
+			HostSigners:        hostSigners,
+			Signers:            signers,
+			NetworkProvider:    network,
+			SessionManager:     sessionManager,
+			Logger:             logger.With("component", "server"),
+			MetricsProvider:    mp,
 		}
 		g.Add(func() error {
 			return s.ServeWithContext(ctx, sshln, wsln)
@@ -286,13 +288,14 @@ func parseNetworkOpt(opts []string) NetworkOptions {
 }
 
 type Server struct {
-	NodeAddr        string
-	HostSigners     []ssh.Signer
-	Signers         []ssh.Signer
-	NetworkProvider NetworkProvider
-	MetricsProvider provider.Provider
-	SessionManager  *SessionManager
-	Logger          *slog.Logger
+	NodeAddr           string
+	AuthorizedKeysFile string
+	HostSigners        []ssh.Signer
+	Signers            []ssh.Signer
+	NetworkProvider    NetworkProvider
+	MetricsProvider    provider.Provider
+	SessionManager     *SessionManager
+	Logger             *slog.Logger
 
 	sshln net.Listener
 	wsln  net.Listener
@@ -369,13 +372,14 @@ func (s *Server) ServeWithContext(ctx context.Context, sshln net.Listener, wsln 
 				Logger:              s.Logger.With("component", "ssh-conn-dialer"),
 			}
 			sp := &sshProxy{
-				HostSigners:     s.HostSigners,
-				Signers:         s.Signers,
-				NodeAddr:        s.NodeAddr,
-				ConnDialer:      cd,
-				SessionManager:  s.SessionManager,
-				Logger:          s.Logger.With("component", "ssh-proxy"),
-				MetricsProvider: s.MetricsProvider,
+				HostSigners:        s.HostSigners,
+				Signers:            s.Signers,
+				NodeAddr:           s.NodeAddr,
+				AuthorizedKeysFile: s.AuthorizedKeysFile,
+				ConnDialer:         cd,
+				SessionManager:     s.SessionManager,
+				Logger:             s.Logger.With("component", "ssh-proxy"),
+				MetricsProvider:    s.MetricsProvider,
 			}
 			g.Add(func() error {
 				return sp.Serve(sshln)

--- a/server/server.go
+++ b/server/server.go
@@ -30,21 +30,21 @@ const (
 )
 
 type Opt struct {
-	SSHAddr            string       `mapstructure:"ssh-addr"`
-	SSHProxyProtocol   bool         `mapstructure:"ssh-proxy-protocol"`
-	WSAddr             string       `mapstructure:"ws-addr"`
-	NodeAddr           string       `mapstructure:"node-addr"`
-	AuthorizedKeysFile string       `mapstructure:"authorized-keys"`
-	PrivateKeys        []string     `mapstructure:"private-key"`
-	Hostnames          []string     `mapstructure:"hostname"`
-	Network            string       `mapstructure:"network"`
-	NetworkOpts        []string     `mapstructure:"network-opt"`
-	MetricAddr         string       `mapstructure:"metric-addr"`
-	Debug              bool         `mapstructure:"debug"`
-	Routing            routing.Mode `mapstructure:"routing"`
-	ConsulURL          string       `mapstructure:"consul-url"`
-	ConsulSessionTTL   string       `mapstructure:"consul-session-ttl"`
-	SentryDSN          string       `mapstructure:"sentry-dsn"`
+	SSHAddr             string       `mapstructure:"ssh-addr"`
+	SSHProxyProtocol    bool         `mapstructure:"ssh-proxy-protocol"`
+	WSAddr              string       `mapstructure:"ws-addr"`
+	NodeAddr            string       `mapstructure:"node-addr"`
+	AuthorizedKeysFiles []string     `mapstructure:"authorized-keys"`
+	PrivateKeys         []string     `mapstructure:"private-key"`
+	Hostnames           []string     `mapstructure:"hostname"`
+	Network             string       `mapstructure:"network"`
+	NetworkOpts         []string     `mapstructure:"network-opt"`
+	MetricAddr          string       `mapstructure:"metric-addr"`
+	Debug               bool         `mapstructure:"debug"`
+	Routing             routing.Mode `mapstructure:"routing"`
+	ConsulURL           string       `mapstructure:"consul-url"`
+	ConsulSessionTTL    string       `mapstructure:"consul-session-ttl"`
+	SentryDSN           string       `mapstructure:"sentry-dsn"`
 }
 
 // Validate validates the server configuration
@@ -241,14 +241,14 @@ func Start(ctx context.Context, opt Opt, logger *slog.Logger) error {
 		}
 
 		s := &Server{
-			NodeAddr:           nodeAddr,
-			AuthorizedKeysFile: opt.AuthorizedKeysFile,
-			HostSigners:        hostSigners,
-			Signers:            signers,
-			NetworkProvider:    network,
-			SessionManager:     sessionManager,
-			Logger:             logger.With("component", "server"),
-			MetricsProvider:    mp,
+			NodeAddr:            nodeAddr,
+			AuthorizedKeysFiles: opt.AuthorizedKeysFiles,
+			HostSigners:         hostSigners,
+			Signers:             signers,
+			NetworkProvider:     network,
+			SessionManager:      sessionManager,
+			Logger:              logger.With("component", "server"),
+			MetricsProvider:     mp,
 		}
 		g.Add(func() error {
 			return s.ServeWithContext(ctx, sshln, wsln)
@@ -288,14 +288,14 @@ func parseNetworkOpt(opts []string) NetworkOptions {
 }
 
 type Server struct {
-	NodeAddr           string
-	AuthorizedKeysFile string
-	HostSigners        []ssh.Signer
-	Signers            []ssh.Signer
-	NetworkProvider    NetworkProvider
-	MetricsProvider    provider.Provider
-	SessionManager     *SessionManager
-	Logger             *slog.Logger
+	NodeAddr            string
+	AuthorizedKeysFiles []string
+	HostSigners         []ssh.Signer
+	Signers             []ssh.Signer
+	NetworkProvider     NetworkProvider
+	MetricsProvider     provider.Provider
+	SessionManager      *SessionManager
+	Logger              *slog.Logger
 
 	sshln net.Listener
 	wsln  net.Listener
@@ -372,14 +372,14 @@ func (s *Server) ServeWithContext(ctx context.Context, sshln net.Listener, wsln 
 				Logger:              s.Logger.With("component", "ssh-conn-dialer"),
 			}
 			sp := &sshProxy{
-				HostSigners:        s.HostSigners,
-				Signers:            s.Signers,
-				NodeAddr:           s.NodeAddr,
-				AuthorizedKeysFile: s.AuthorizedKeysFile,
-				ConnDialer:         cd,
-				SessionManager:     s.SessionManager,
-				Logger:             s.Logger.With("component", "ssh-proxy"),
-				MetricsProvider:    s.MetricsProvider,
+				HostSigners:         s.HostSigners,
+				Signers:             s.Signers,
+				NodeAddr:            s.NodeAddr,
+				AuthorizedKeysFiles: s.AuthorizedKeysFiles,
+				ConnDialer:          cd,
+				SessionManager:      s.SessionManager,
+				Logger:              s.Logger.With("component", "ssh-proxy"),
+				MetricsProvider:     s.MetricsProvider,
 			}
 			g.Add(func() error {
 				return sp.Serve(sshln)

--- a/server/sshproxy.go
+++ b/server/sshproxy.go
@@ -15,14 +15,14 @@ import (
 )
 
 type sshProxy struct {
-	HostSigners        []ssh.Signer
-	Signers            []ssh.Signer
-	NodeAddr           string
-	AuthorizedKeysFile string
-	ConnDialer         connDialer
-	SessionManager     *SessionManager
-	Logger             *slog.Logger
-	MetricsProvider    provider.Provider
+	HostSigners         []ssh.Signer
+	Signers             []ssh.Signer
+	NodeAddr            string
+	AuthorizedKeysFiles []string
+	ConnDialer          connDialer
+	SessionManager      *SessionManager
+	Logger              *slog.Logger
+	MetricsProvider     provider.Provider
 
 	routing *SSHRouting
 	mux     sync.Mutex
@@ -40,17 +40,22 @@ func (r *sshProxy) Shutdown() error {
 }
 
 func (r *sshProxy) Serve(ln net.Listener) error {
+	authorizedKeys, err := loadAuthorizedKeys(r.AuthorizedKeysFiles)
+	if err != nil {
+		return err
+	}
+
 	r.mux.Lock()
 	r.routing = &SSHRouting{
 		HostSigners: r.HostSigners,
 		AuthPiper: &authPiper{
-			HostSigners:        r.HostSigners,
-			Signers:            r.Signers,
-			SessionManager:     r.SessionManager,
-			ConnDialer:         r.ConnDialer,
-			NodeAddr:           r.NodeAddr,
-			AuthorizedKeysFile: r.AuthorizedKeysFile,
-			Logger:             r.Logger.With("component", "auth"),
+			HostSigners:    r.HostSigners,
+			Signers:        r.Signers,
+			SessionManager: r.SessionManager,
+			ConnDialer:     r.ConnDialer,
+			NodeAddr:       r.NodeAddr,
+			authorizedKeys: authorizedKeys,
+			Logger:         r.Logger.With("component", "auth"),
 		},
 		Decoder:         r.SessionManager.GetEncodeDecoder(),
 		MetricsProvider: r.MetricsProvider,
@@ -62,47 +67,63 @@ func (r *sshProxy) Serve(ln net.Listener) error {
 }
 
 type authPiper struct {
-	NodeAddr           string
-	AuthorizedKeysFile string
-	SessionManager     *SessionManager
-	ConnDialer         connDialer
-	Signers            []ssh.Signer
-	HostSigners        []ssh.Signer
+	NodeAddr       string
+	authorizedKeys map[string]struct{} // SHA256 fingerprints; nil disables the gate
+	SessionManager *SessionManager
+	ConnDialer     connDialer
+	Signers        []ssh.Signer
+	HostSigners    []ssh.Signer
 
 	Logger *slog.Logger
 }
 
-func (a authPiper) CheckAuthorizedKeys(conn ssh.ConnMetadata, pk ssh.PublicKey) (ssh.PublicKey, error) {
-	if a.AuthorizedKeysFile == "" {
-		return pk, nil
+func (a authPiper) checkAuthorizedKeys(conn ssh.ConnMetadata, pk ssh.PublicKey) error {
+	if a.authorizedKeys == nil {
+		return nil
 	}
 
 	// Only HOST connections (uptermd hosts registering with the proxy) are gated by authorized_keys.
 	if string(conn.ClientVersion()) != upterm.HostSSHClientVersion {
-		return pk, nil
+		return nil
 	}
 
-	rest, err := os.ReadFile(a.AuthorizedKeysFile)
-	if err != nil {
-		a.Logger.Error("unable to load custom authorized_keys file", "path", a.AuthorizedKeysFile)
-		return nil, err
+	fp := utils.FingerprintSHA256(pk)
+	if _, ok := a.authorizedKeys[fp]; ok {
+		a.Logger.Info("access granted", "fingerprint", fp)
+		return nil
 	}
 
-	var authedPubkey ssh.PublicKey
-	for len(rest) > 0 {
-		authedPubkey, _, _, rest, err = ssh.ParseAuthorizedKey(rest)
+	a.Logger.Warn("access denied", "fingerprint", fp)
+	return fmt.Errorf("public key is not authorized")
+}
+
+// loadAuthorizedKeys reads the configured authorized_keys files once at
+// startup and returns the set of SHA256 fingerprints permitted to register
+// as hosts. Returns nil when paths is empty, signaling that the gate is
+// disabled. Edits to the files require restarting uptermd to take effect.
+func loadAuthorizedKeys(paths []string) (map[string]struct{}, error) {
+	if len(paths) == 0 {
+		return nil, nil
+	}
+
+	fps := make(map[string]struct{})
+	for _, path := range paths {
+		rest, err := os.ReadFile(path)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("read authorized_keys %s: %w", path, err)
 		}
 
-		if utils.KeysEqual(authedPubkey, pk) {
-			a.Logger.Info("access granted", "fingerprint", utils.FingerprintSHA256(pk))
-			return pk, nil
+		for len(rest) > 0 {
+			pk, _, _, next, perr := ssh.ParseAuthorizedKey(rest)
+			if perr != nil {
+				// No more parseable keys (trailing comments, blanks, or junk).
+				break
+			}
+			rest = next
+			fps[utils.FingerprintSHA256(pk)] = struct{}{}
 		}
 	}
-
-	a.Logger.Info("access denied", "fingerprint", utils.FingerprintSHA256(pk))
-	return nil, fmt.Errorf("public key is not authorized")
+	return fps, nil
 }
 
 func (a authPiper) PublicKeyCallback(conn ssh.ConnMetadata, pk ssh.PublicKey, challengeCtx ssh.ChallengeContext) (*ssh.Upstream, error) {
@@ -112,9 +133,8 @@ func (a authPiper) PublicKeyCallback(conn ssh.ConnMetadata, pk ssh.PublicKey, ch
 		},
 	}
 
-	// Check for authorized_hosts to allow proxying.
-	_, err := a.CheckAuthorizedKeys(conn, pk)
-	if err != nil {
+	// Gate registration based on authorized_keys before any cert/upstream work.
+	if err := a.checkAuthorizedKeys(conn, pk); err != nil {
 		return nil, err
 	}
 

--- a/server/sshproxy.go
+++ b/server/sshproxy.go
@@ -87,7 +87,7 @@ func (a authPiper) checkAuthorizedKeys(conn ssh.ConnMetadata, pk ssh.PublicKey) 
 		return nil
 	}
 
-	fp := utils.FingerprintSHA256(pk)
+	fp := publicKeyFingerprint(pk)
 	if _, ok := a.authorizedKeys[fp]; ok {
 		a.Logger.Info("access granted", "fingerprint", fp)
 		return nil
@@ -95,6 +95,18 @@ func (a authPiper) checkAuthorizedKeys(conn ssh.ConnMetadata, pk ssh.PublicKey) 
 
 	a.Logger.Warn("access denied", "fingerprint", fp)
 	return fmt.Errorf("public key is not authorized")
+}
+
+// publicKeyFingerprint returns the SHA256 fingerprint of the underlying
+// public key, unwrapping any SSH certificate. authorized_keys files contain
+// raw key entries, but hosts authenticating with a CertSigner (commonly
+// supplied by ssh-agent) present a certificate; matching must be done on
+// the underlying key identity, not the certificate blob.
+func publicKeyFingerprint(pk ssh.PublicKey) string {
+	if cert, ok := pk.(*ssh.Certificate); ok {
+		pk = cert.Key
+	}
+	return utils.FingerprintSHA256(pk)
 }
 
 // loadAuthorizedKeys reads the configured authorized_keys files once at
@@ -120,7 +132,7 @@ func loadAuthorizedKeys(paths []string) (map[string]struct{}, error) {
 				break
 			}
 			rest = next
-			fps[utils.FingerprintSHA256(pk)] = struct{}{}
+			fps[publicKeyFingerprint(pk)] = struct{}{}
 		}
 	}
 	return fps, nil

--- a/server/sshproxy.go
+++ b/server/sshproxy.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"os"
 	"sync"
 
 	"github.com/go-kit/kit/metrics/provider"
@@ -14,13 +15,14 @@ import (
 )
 
 type sshProxy struct {
-	HostSigners     []ssh.Signer
-	Signers         []ssh.Signer
-	NodeAddr        string
-	ConnDialer      connDialer
-	SessionManager  *SessionManager
-	Logger          *slog.Logger
-	MetricsProvider provider.Provider
+	HostSigners        []ssh.Signer
+	Signers            []ssh.Signer
+	NodeAddr           string
+	AuthorizedKeysFile string
+	ConnDialer         connDialer
+	SessionManager     *SessionManager
+	Logger             *slog.Logger
+	MetricsProvider    provider.Provider
 
 	routing *SSHRouting
 	mux     sync.Mutex
@@ -42,11 +44,13 @@ func (r *sshProxy) Serve(ln net.Listener) error {
 	r.routing = &SSHRouting{
 		HostSigners: r.HostSigners,
 		AuthPiper: &authPiper{
-			HostSigners:    r.HostSigners,
-			Signers:        r.Signers,
-			SessionManager: r.SessionManager,
-			ConnDialer:     r.ConnDialer,
-			NodeAddr:       r.NodeAddr,
+			HostSigners:        r.HostSigners,
+			Signers:            r.Signers,
+			SessionManager:     r.SessionManager,
+			ConnDialer:         r.ConnDialer,
+			NodeAddr:           r.NodeAddr,
+			AuthorizedKeysFile: r.AuthorizedKeysFile,
+			Logger:             r.Logger.With("component", "auth"),
 		},
 		Decoder:         r.SessionManager.GetEncodeDecoder(),
 		MetricsProvider: r.MetricsProvider,
@@ -58,11 +62,47 @@ func (r *sshProxy) Serve(ln net.Listener) error {
 }
 
 type authPiper struct {
-	NodeAddr       string
-	SessionManager *SessionManager
-	ConnDialer     connDialer
-	Signers        []ssh.Signer
-	HostSigners    []ssh.Signer
+	NodeAddr           string
+	AuthorizedKeysFile string
+	SessionManager     *SessionManager
+	ConnDialer         connDialer
+	Signers            []ssh.Signer
+	HostSigners        []ssh.Signer
+
+	Logger *slog.Logger
+}
+
+func (a authPiper) CheckAuthorizedKeys(conn ssh.ConnMetadata, pk ssh.PublicKey) (ssh.PublicKey, error) {
+	if a.AuthorizedKeysFile == "" {
+		return pk, nil
+	}
+
+	// Only HOST connections (uptermd hosts registering with the proxy) are gated by authorized_keys.
+	if string(conn.ClientVersion()) != upterm.HostSSHClientVersion {
+		return pk, nil
+	}
+
+	rest, err := os.ReadFile(a.AuthorizedKeysFile)
+	if err != nil {
+		a.Logger.Error("unable to load custom authorized_keys file", "path", a.AuthorizedKeysFile)
+		return nil, err
+	}
+
+	var authedPubkey ssh.PublicKey
+	for len(rest) > 0 {
+		authedPubkey, _, _, rest, err = ssh.ParseAuthorizedKey(rest)
+		if err != nil {
+			return nil, err
+		}
+
+		if utils.KeysEqual(authedPubkey, pk) {
+			a.Logger.Info("access granted", "fingerprint", utils.FingerprintSHA256(pk))
+			return pk, nil
+		}
+	}
+
+	a.Logger.Info("access denied", "fingerprint", utils.FingerprintSHA256(pk))
+	return nil, fmt.Errorf("public key is not authorized")
 }
 
 func (a authPiper) PublicKeyCallback(conn ssh.ConnMetadata, pk ssh.PublicKey, challengeCtx ssh.ChallengeContext) (*ssh.Upstream, error) {
@@ -71,6 +111,13 @@ func (a authPiper) PublicKeyCallback(conn ssh.ConnMetadata, pk ssh.PublicKey, ch
 			return key, nil
 		},
 	}
+
+	// Check for authorized_hosts to allow proxying.
+	_, err := a.CheckAuthorizedKeys(conn, pk)
+	if err != nil {
+		return nil, err
+	}
+
 	auth, key, err := checker.Authenticate(conn.User(), pk)
 	if err == errCertNotSignedByHost {
 		err = nil

--- a/server/sshproxy_test.go
+++ b/server/sshproxy_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/owenthereal/upterm/upterm"
 	"github.com/owenthereal/upterm/utils"
 	"github.com/rs/xid"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -163,78 +164,142 @@ func testCertSigner(user string, signer ssh.Signer) (ssh.Signer, error) {
 	return ssh.NewCertSigner(cert, signer)
 }
 
-func Test_sshProxy_CheckAuthorizedKeys(t *testing.T) {
+// fakeConnMetadata is a minimal ssh.ConnMetadata stub for unit-testing
+// authPiper.checkAuthorizedKeys, which only consults ClientVersion.
+type fakeConnMetadata struct {
+	clientVersion string
+}
+
+func (f *fakeConnMetadata) User() string          { return "" }
+func (f *fakeConnMetadata) SessionID() []byte     { return nil }
+func (f *fakeConnMetadata) ClientVersion() []byte { return []byte(f.clientVersion) }
+func (f *fakeConnMetadata) ServerVersion() []byte { return nil }
+func (f *fakeConnMetadata) RemoteAddr() net.Addr  { return nil }
+func (f *fakeConnMetadata) LocalAddr() net.Addr   { return nil }
+
+func writeKeyFile(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "authorized_keys")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0600))
+	return path
+}
+
+func Test_loadAuthorizedKeys(t *testing.T) {
+	hostSigner, err := ssh.ParsePrivateKey([]byte(HostPrivateKeyContent))
+	require.NoError(t, err)
+	hostFp := utils.FingerprintSHA256(hostSigner.PublicKey())
+
+	otherSigner, err := ssh.ParsePrivateKey([]byte(TestPrivateKeyContent))
+	require.NoError(t, err)
+	otherPubKeyLine := string(ssh.MarshalAuthorizedKey(otherSigner.PublicKey()))
+	otherFp := utils.FingerprintSHA256(otherSigner.PublicKey())
+
+	t.Run("nil paths returns nil set (gate disabled)", func(t *testing.T) {
+		got, err := loadAuthorizedKeys(nil)
+		require.NoError(t, err)
+		require.Nil(t, got)
+	})
+
+	t.Run("single file is parsed into fingerprint set", func(t *testing.T) {
+		got, err := loadAuthorizedKeys([]string{writeKeyFile(t, HostPublicKeyContent+"\n")})
+		require.NoError(t, err)
+		require.Contains(t, got, hostFp)
+		require.Len(t, got, 1)
+	})
+
+	t.Run("multiple files are unioned", func(t *testing.T) {
+		got, err := loadAuthorizedKeys([]string{
+			writeKeyFile(t, HostPublicKeyContent+"\n"),
+			writeKeyFile(t, otherPubKeyLine),
+		})
+		require.NoError(t, err)
+		require.Contains(t, got, hostFp)
+		require.Contains(t, got, otherFp)
+	})
+
+	t.Run("comment-only file yields empty set, not an error", func(t *testing.T) {
+		got, err := loadAuthorizedKeys([]string{writeKeyFile(t, "# header\n# nothing else\n")})
+		require.NoError(t, err)
+		require.Empty(t, got)
+	})
+
+	t.Run("missing file fails fast", func(t *testing.T) {
+		_, err := loadAuthorizedKeys([]string{filepath.Join(t.TempDir(), "does-not-exist")})
+		require.Error(t, err)
+	})
+}
+
+func Test_authPiper_checkAuthorizedKeys(t *testing.T) {
 	logger := logging.Must(logging.Console(), logging.Debug()).Logger
 
-	proxySigner, err := ssh.ParsePrivateKey([]byte(TestPrivateKeyContent))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	cs := HostCertSigner{
-		Hostnames: []string{"127.0.0.1"},
-	}
-	proxyCertSigner, err := cs.SignCert(proxySigner)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	proxyLn, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		_ = proxyLn.Close()
-	}()
-
-	proxyAddr := proxyLn.Addr().String()
-	cd := sidewayConnDialer{
-		NodeAddr:         proxyAddr,
-		NeighbourDialer:  tcpConnDialer{},
-		Logger:           logger,
-		SSHDDialListener: networks.Get("mem").SSHD(),
-	}
-
-	tempfile := filepath.Join(t.TempDir(), "authorized_keys")
-	if err := os.WriteFile(tempfile, []byte(HostPublicKeyContent), 0600); err != nil {
-		t.Fatal(err)
-	}
-
-	proxy := &sshProxy{
-		HostSigners:        []ssh.Signer{proxyCertSigner},
-		Signers:            []ssh.Signer{proxySigner},
-		NodeAddr:           proxyAddr,
-		AuthorizedKeysFile: tempfile,
-		ConnDialer:         cd,
-		SessionManager:     newEmbeddedSessionManager(logger),
-		Logger:             logger,
-		MetricsProvider:    provider.NewDiscardProvider(),
-	}
-
-	go func() {
-		_ = proxy.Serve(proxyLn)
-	}()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	if err := utils.WaitForServer(ctx, proxyAddr); err != nil {
-		t.Fatal(err)
-	}
-
 	hostSigner, err := ssh.ParsePrivateKey([]byte(HostPrivateKeyContent))
-	if err != nil {
-		t.Fatal(err)
+	require.NoError(t, err)
+	hostPubKey := hostSigner.PublicKey()
+	hostFp := utils.FingerprintSHA256(hostPubKey)
+
+	otherSigner, err := ssh.ParsePrivateKey([]byte(TestPrivateKeyContent))
+	require.NoError(t, err)
+	otherFp := utils.FingerprintSHA256(otherSigner.PublicKey())
+
+	hostMeta := &fakeConnMetadata{clientVersion: upterm.HostSSHClientVersion}
+	clientMeta := &fakeConnMetadata{clientVersion: "SSH-2.0-OpenSSH_9.0"}
+
+	cases := []struct {
+		name      string
+		keys      map[string]struct{}
+		meta      ssh.ConnMetadata
+		offered   ssh.PublicKey
+		wantGrant bool
+	}{
+		{
+			name:      "nil set bypasses gate",
+			keys:      nil,
+			meta:      hostMeta,
+			offered:   hostPubKey,
+			wantGrant: true,
+		},
+		{
+			name:      "non-host client version bypasses gate",
+			keys:      map[string]struct{}{otherFp: {}}, // host key NOT in set
+			meta:      clientMeta,
+			offered:   hostPubKey,
+			wantGrant: true,
+		},
+		{
+			name:      "host key present in set is granted",
+			keys:      map[string]struct{}{hostFp: {}},
+			meta:      hostMeta,
+			offered:   hostPubKey,
+			wantGrant: true,
+		},
+		{
+			name:      "host key absent from non-empty set is denied",
+			keys:      map[string]struct{}{otherFp: {}},
+			meta:      hostMeta,
+			offered:   hostPubKey,
+			wantGrant: false,
+		},
+		{
+			name:      "empty (non-nil) set denies all hosts",
+			keys:      map[string]struct{}{},
+			meta:      hostMeta,
+			offered:   hostPubKey,
+			wantGrant: false,
+		},
 	}
 
-	// HOST connections identify themselves via the SSH client banner; the User
-	// field carries the session ID directly (no encoding).
-	config := &ssh.ClientConfig{
-		User:            xid.New().String(),
-		Auth:            []ssh.AuthMethod{ssh.PublicKeys(hostSigner)},
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
-		ClientVersion:   upterm.HostSSHClientVersion,
-	}
-	if _, err := ssh.Dial("tcp", proxyAddr, config); err != nil {
-		t.Fatal(err)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := authPiper{
+				authorizedKeys: tc.keys,
+				Logger:         logger,
+			}
+			err := a.checkAuthorizedKeys(tc.meta, tc.offered)
+			if tc.wantGrant {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+		})
 	}
 }

--- a/server/sshproxy_test.go
+++ b/server/sshproxy_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"crypto/rand"
 	"net"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -11,9 +13,21 @@ import (
 	"github.com/go-kit/kit/metrics/provider"
 	"github.com/owenthereal/upterm/internal/logging"
 	"github.com/owenthereal/upterm/routing"
+	"github.com/owenthereal/upterm/upterm"
 	"github.com/owenthereal/upterm/utils"
 	"github.com/rs/xid"
 	"golang.org/x/crypto/ssh"
+)
+
+const (
+	HostPublicKeyContent  = `ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOA+rMcwWFPJVE2g6EwRPkYmNJfaS/+gkyZ99aR/65uz`
+	HostPrivateKeyContent = `-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+QyNTUxOQAAACDgPqzHMFhTyVRNoOhMET5GJjSX2kv/oJMmffWkf+ubswAAAIiu5GOBruRj
+gQAAAAtzc2gtZWQyNTUxOQAAACDgPqzHMFhTyVRNoOhMET5GJjSX2kv/oJMmffWkf+ubsw
+AAAEDBHlsR95C/pGVHtQGpgrUi+Qwgkfnp9QlRKdEhhx4rxOA+rMcwWFPJVE2g6EwRPkYm
+NJfaS/+gkyZ99aR/65uzAAAAAAECAwQF
+-----END OPENSSH PRIVATE KEY-----`
 )
 
 func Test_sshProxy_dialUpstream(t *testing.T) {
@@ -147,4 +161,80 @@ func testCertSigner(user string, signer ssh.Signer) (ssh.Signer, error) {
 	}
 
 	return ssh.NewCertSigner(cert, signer)
+}
+
+func Test_sshProxy_CheckAuthorizedKeys(t *testing.T) {
+	logger := logging.Must(logging.Console(), logging.Debug()).Logger
+
+	proxySigner, err := ssh.ParsePrivateKey([]byte(TestPrivateKeyContent))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cs := HostCertSigner{
+		Hostnames: []string{"127.0.0.1"},
+	}
+	proxyCertSigner, err := cs.SignCert(proxySigner)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	proxyLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = proxyLn.Close()
+	}()
+
+	proxyAddr := proxyLn.Addr().String()
+	cd := sidewayConnDialer{
+		NodeAddr:         proxyAddr,
+		NeighbourDialer:  tcpConnDialer{},
+		Logger:           logger,
+		SSHDDialListener: networks.Get("mem").SSHD(),
+	}
+
+	tempfile := filepath.Join(t.TempDir(), "authorized_keys")
+	if err := os.WriteFile(tempfile, []byte(HostPublicKeyContent), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	proxy := &sshProxy{
+		HostSigners:        []ssh.Signer{proxyCertSigner},
+		Signers:            []ssh.Signer{proxySigner},
+		NodeAddr:           proxyAddr,
+		AuthorizedKeysFile: tempfile,
+		ConnDialer:         cd,
+		SessionManager:     newEmbeddedSessionManager(logger),
+		Logger:             logger,
+		MetricsProvider:    provider.NewDiscardProvider(),
+	}
+
+	go func() {
+		_ = proxy.Serve(proxyLn)
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := utils.WaitForServer(ctx, proxyAddr); err != nil {
+		t.Fatal(err)
+	}
+
+	hostSigner, err := ssh.ParsePrivateKey([]byte(HostPrivateKeyContent))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// HOST connections identify themselves via the SSH client banner; the User
+	// field carries the session ID directly (no encoding).
+	config := &ssh.ClientConfig{
+		User:            xid.New().String(),
+		Auth:            []ssh.AuthMethod{ssh.PublicKeys(hostSigner)},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		ClientVersion:   upterm.HostSSHClientVersion,
+	}
+	if _, err := ssh.Dial("tcp", proxyAddr, config); err != nil {
+		t.Fatal(err)
+	}
 }

--- a/server/sshproxy_test.go
+++ b/server/sshproxy_test.go
@@ -237,6 +237,12 @@ func Test_authPiper_checkAuthorizedKeys(t *testing.T) {
 	hostPubKey := hostSigner.PublicKey()
 	hostFp := utils.FingerprintSHA256(hostPubKey)
 
+	// Wrap the host's key in a certificate to mimic an agent-provided CertSigner:
+	// the SSH library passes the certificate (not the raw key) to PublicKeyCallback.
+	hostCertSigner, err := testCertSigner("host", hostSigner)
+	require.NoError(t, err)
+	hostCertAsPubKey := hostCertSigner.PublicKey()
+
 	otherSigner, err := ssh.ParsePrivateKey([]byte(TestPrivateKeyContent))
 	require.NoError(t, err)
 	otherFp := utils.FingerprintSHA256(otherSigner.PublicKey())
@@ -284,6 +290,20 @@ func Test_authPiper_checkAuthorizedKeys(t *testing.T) {
 			keys:      map[string]struct{}{},
 			meta:      hostMeta,
 			offered:   hostPubKey,
+			wantGrant: false,
+		},
+		{
+			name:      "cert is matched against its underlying key (in set)",
+			keys:      map[string]struct{}{hostFp: {}},
+			meta:      hostMeta,
+			offered:   hostCertAsPubKey,
+			wantGrant: true,
+		},
+		{
+			name:      "cert is matched against its underlying key (absent)",
+			keys:      map[string]struct{}{otherFp: {}},
+			meta:      hostMeta,
+			offered:   hostCertAsPubKey,
 			wantGrant: false,
 		},
 	}


### PR DESCRIPTION
#213 no longer merges cleanly. This PR provides all the functionality contributed by @mbutkereit, as well as relevant changes to the Helm chart to support authorized keys.