### PR TITLE
increaase pipeEstablishingTimeout to 60s

### DIFF
--- a/server/sshrouting.go
+++ b/server/sshrouting.go
@@ -17,7 +17,7 @@ import (
 
 var (
 	ErrListnerClosed        = errors.New("routing: listener closed")
-	pipeEstablishingTimeout = 3 * time.Second
+	pipeEstablishingTimeout = 60 * time.Second
 )
 
 type SSHRouting struct {


### PR DESCRIPTION
When using encrypted ssh keys, ssh-agent or an external authenticator (e.g. yubikey), there might be an time interval in which the user has to perform a manual action (typing ssh key password, approving the agent connection, physically touching the yubikey), which will take longer than the 3s timeout that is in place, causing the
connection to be closed with no further explanation:

```console
$ ssh <session_id>@uptermd.upterm.dev
Enter passphrase for key '/home/dtrifiro/.ssh/id_ed25519':
Connection closed by 37.16.25.99 port 22
```

Increasing the timeout to 60s fixes this issue.
