### PR TITLE
Fix macOS Gatekeeper quarantine issue for Homebrew cask

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -73,6 +73,12 @@ homebrew_casks:
     completions:
       bash: "etc/completion/upterm.bash_completion.sh"
       zsh: "etc/completion/upterm.zsh_completion"
+    hooks:
+      post:
+        install: |
+          if system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/upterm"]
+          end
 dockers:
   - image_templates:
       - "{{ .Env.DOCKER_REPO }}:{{ .Tag }}-amd64"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This is a [blog post](https://owenou.com/upterm) to describe Upterm in depth.
 ### Mac
 
 ```console
-brew install --cask owenthereal/upterm/upterm
+brew install owenthereal/upterm/upterm
 ```
 
 ### Standalone


### PR DESCRIPTION
## Summary
- Add post-install hook to remove quarantine attribute from upterm binary
- Prevents macOS Gatekeeper "Not Opened" security dialog 
- Eliminates need for users to manually bypass security warnings

## Test plan
- [ ] Test Homebrew cask installation on macOS
- [ ] Verify no Gatekeeper dialog appears after installation
- [ ] Confirm upterm binary runs without security warnings