### PR TITLE
Dockerfile: revert default stage to pre-built-binary

### DIFF
--- a/Dockerfile.uptermd
+++ b/Dockerfile.uptermd
@@ -31,6 +31,3 @@ ENTRYPOINT ["uptermd-fly"]
 FROM base AS pre-built-binary
 COPY uptermd /app/
 ENTRYPOINT ["uptermd"]
-
-# Default stage - Fly deployment
-FROM uptermd-fly


### PR DESCRIPTION
Please consider merging this one. What used to work before (build and run with no `--target=pre-built-binary`) does not work anymore, because the fly image doesn't work in other scenarios:

Building the dockerfile with and running it fails:

```bash
docker build -f Dockerfile.uptermd -t uptermd .
docker run -it --rm uptermd
```

Results in

> FATA[0000] FLY_APP_NAME is not set

Now we have to add `docker build -f Dockerfile.uptermd --target=pre-built-binary` in order for this to work
