### PR TITLE
Remove conflict_with

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -52,8 +52,6 @@ homebrew_casks:
     commit_author:
       name: Owen Ou
       email: o@owenou.com
-    conflicts:
-      - formula: upterm
     homepage: https://upterm.dev
     description: Instant Terminal Sharing
     directory: Casks


### PR DESCRIPTION
Got the following error:

```
Warning: Calling conflicts_with formula: is deprecated! There is no replacement.
Please report this issue to the owenthereal/homebrew-upterm tap (not Homebrew/* repositories):
  /opt/homebrew/Library/Taps/owenthereal/homebrew-upterm/Casks/upterm.rb:46
```
