### PR TITLE
Default dockerfile stage

### DIFF
--- a/Dockerfile.uptermd
+++ b/Dockerfile.uptermd
@@ -32,5 +32,7 @@ FROM base AS pre-built-binary
 COPY uptermd /app/
 ENTRYPOINT ["uptermd"]
 
-# Default stage - Fly deployment
-FROM uptermd-fly
+# Default stage
+FROM base AS uptermd
+COPY --from=builder /go/bin/uptermd /app/
+ENTRYPOINT ["uptermd"]


### PR DESCRIPTION
Revert default Dockerfile.upterm stage to copy uptermd from Docker build

This closes https://github.com/owenthereal/upterm/pull/341 & https://github.com/owenthereal/upterm/pull/340/ 
