### PR TITLE
Add a flag to hide IPs from session list.

### DIFF
--- a/cmd/upterm/command/session.go
+++ b/cmd/upterm/command/session.go
@@ -19,7 +19,8 @@ import (
 )
 
 var (
-	flagAdminSocket string
+	flagAdminSocket  string
+	flagHideClientIp bool
 )
 
 func sessionCmd() *cobra.Command {
@@ -81,6 +82,7 @@ sharing a session with 'upterm host'.`,
 	}
 
 	cmd.PersistentFlags().StringVarP(&flagAdminSocket, "admin-socket", "", currentAdminSocketFile(), "admin unix domain socket (required)")
+	cmd.PersistentFlags().BoolVarP(&flagHideClientIp, "hide-client-ip", "", false, "hide client IPs from session list")
 
 	return cmd
 }
@@ -294,6 +296,9 @@ func displaySession(session *api.GetSessionResponse) error {
 }
 
 func clientDesc(addr, clientVer, fingerprint string) string {
+	if flagHideClientIp {
+		addr = "[ip hidden]"
+	}
 	return fmt.Sprintf("%s %s %s", addr, clientVer, fingerprint)
 }
 


### PR DESCRIPTION
Hi, I love this project.

But I sometimes want to hide my IP address from the session list.
This is especially useful in the context of actions, where exposing your public IP address to everyone might not be a good idea.

If you merge this PR, I'll submit a change to action-upterm shortly.

This is my first time writing Go, so please point out any errors.

Thanks for your time!