### PR TITLE
Fix version output to remove redundant 'v' prefix

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,7 +13,7 @@ builds:
       - "arm64"
     main: ./cmd/upterm
     ldflags:
-      - -s -w -X github.com/owenthereal/upterm/internal/version.Version={{.Tag}} -X github.com/owenthereal/upterm/internal/version.GitCommit={{.Commit}} -X github.com/owenthereal/upterm/internal/version.Date={{.CommitDate}}
+      - -s -w -X github.com/owenthereal/upterm/internal/version.Version={{.Version}} -X github.com/owenthereal/upterm/internal/version.GitCommit={{.Commit}} -X github.com/owenthereal/upterm/internal/version.Date={{.CommitDate}}
   - id: uptermd
     env:
       - CGO_ENABLED=0
@@ -25,7 +25,7 @@ builds:
     main: ./cmd/uptermd
     binary: uptermd
     ldflags:
-      - -s -w -X github.com/owenthereal/upterm/internal/version.Version={{.Tag}} -X github.com/owenthereal/upterm/internal/version.GitCommit={{.Commit}} -X github.com/owenthereal/upterm/internal/version.Date={{.CommitDate}}
+      - -s -w -X github.com/owenthereal/upterm/internal/version.Version={{.Version}} -X github.com/owenthereal/upterm/internal/version.GitCommit={{.Commit}} -X github.com/owenthereal/upterm/internal/version.Date={{.CommitDate}}
 archives:
   - id: upterm
     name_template: '{{ .Binary }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'

--- a/cmd/upterm/command/upgrade.go
+++ b/cmd/upterm/command/upgrade.go
@@ -75,7 +75,7 @@ func upgradeRunE(c *cobra.Command, args []string) error {
 		r = release{releases[0]}
 	}
 
-	if fmt.Sprintf("v%s", version.String()) == r.Version {
+	if version.String() == trimVPrefix(r.Version) {
 		fmt.Println("Upterm is up-to-date")
 		return nil
 	}


### PR DESCRIPTION
## Summary
- Changes GoReleaser configuration to use `{{.Version}}` instead of `{{.Tag}}`, which automatically strips the 'v' prefix from git tags
- Updates the upgrade command's version comparison logic to work with the new format

## Changes
This fixes the redundant version indicator in the version output. The version command now outputs:
```
Upterm version 0.16.1
```

Instead of:
```
Upterm version v0.16.1
```

## Test plan
- [x] All existing tests pass
- [x] Manual testing with `go build -ldflags` confirms correct output format
- [x] Version comparison logic works correctly in upgrade command

Fixes #382