### PR TITLE
Remove explicit systemd depdency on systemd-networkd-wait-online.service

### DIFF
--- a/systemd/uptermd.service
+++ b/systemd/uptermd.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=upterm secure terminal sharing
 After=network-online.target
-Wants=network-online.target systemd-networkd-wait-online.service
+Wants=network-online.target
 
 [Service]
 ExecStart=/usr/bin/uptermd --ssh-addr 0.0.0.0:2222


### PR DESCRIPTION
I originally added this a long time back but I don't think I was following best practices. Reading the FAQ at https://systemd.io/NETWORK_ONLINE/, it seems to me this is enough.