### PR TITLE
Fix displayAuthorizedKeys to only show colon after username if present

### DIFF
--- a/cmd/upterm/command/session.go
+++ b/cmd/upterm/command/session.go
@@ -336,7 +336,13 @@ func displayAuthorizedKeys(keys []*api.AuthorizedKey) string {
 		for _, fp := range ak.PublicKeyFingerprints {
 			fps = append(fps, fmt.Sprintf("- %s", fp))
 		}
-		aks = append(aks, fmt.Sprintf("%s:\n%s", ak.Comment, strings.Join(fps, "\n")))
+		var line string
+		if ak.Comment != "" {
+			line = fmt.Sprintf("%s:\n%s", ak.Comment, strings.Join(fps, "\n"))
+		} else {
+			line = strings.Join(fps, "\n")
+		}
+		aks = append(aks, line)
 	}
 
 	return strings.Join(aks, "\n")


### PR DESCRIPTION
The `displayAuthorizedKeys` function was always appending a colon after the key comment field, resulting in a trailing colon being printed even when the comment was empty. Now the colon is only added when the comment is non-empty.

E.g. of the "broken ui":

```
╭─ Session: njcvDVH7U7ZkbGBwzy3C ─╮
┌──────────────────────┬────────────────────────────────────────────────────────────────────────────────────┐
│ Command:             │ tmux new -s upterm -x 132 -y 43                                                    │
│ Force Command:       │ tmux attach -t upterm                                                              │
│ Host:                │ ssh://uptermd.upterm.dev:22                                                        │
│ Authorized Keys:     │ mxschmitt:                                                                         │
│                      │                                                                                    │
│ ➤ SSH Command:       │ ssh njcvDVH7U7ZkbGBwzy3C@uptermd.upterm.dev                                        │
│ Connected Client(s): │ [redacted] SSH-2.0-OpenSSH_10.0 SHA256:7TCe2EAokbDP+ZtFgSSC6PJBIGM6dMw36JYA3E8auxI │
└──────────────────────┴────────────────────────────────────────────────────────────────────────────────────┘
╰─ Run 'upterm session current' to display this again ─╯
```