### PR TITLE
Show when GitHub users have no SSH keys configured

### DIFF
--- a/cmd/upterm/command/session.go
+++ b/cmd/upterm/command/session.go
@@ -333,7 +333,7 @@ func displayAuthorizedKeys(keys []*api.AuthorizedKey) string {
 	var aks []string
 	for _, ak := range keys {
 		if len(ak.PublicKeyFingerprints) == 0 {
-			aks = append(aks, fmt.Sprintf("[!] %s (no SSH keys configured)\n", ak.Comment))
+			aks = append(aks, fmt.Sprintf("[!] %s (no SSH keys configured)", ak.Comment))
 		} else {
 			var fps []string
 			for _, fp := range ak.PublicKeyFingerprints {


### PR DESCRIPTION
When specifying GitHub users with `--github-user`, display a clear indicator in the authorized keys section if a user has no SSH keys configured. This helps users understand why a particular user won't be able to connect to the session.

The `[!]` prefix visually distinguishes these users while keeping the message informative and non-alarming. We use `[!]` instead of an emoji because emojis have inconsistent rendering across different terminal emulators (`iTerm2`, `Terminal.app`, `VSCode`), which breaks table alignment and column spacing. See e.g. https://github.com/mattn/go-runewidth/issues/59 which is used by tablewriter.

Relates https://github.com/owenthereal/upterm/pull/391#issuecomment-3469596097