### PR TITLE
Fix version injection for Fly.io deployment

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,18 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: superfly/flyctl-actions/setup-flyctl@master
-      - run: flyctl deploy --remote-only
+      - name: Get version from tag
+        id: version
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "git_commit=$GITHUB_SHA" >> $GITHUB_OUTPUT
+          echo "build_date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
+      - name: Deploy to Fly.io
+        run: |
+          flyctl deploy --remote-only \
+            --build-arg VERSION=${{ steps.version.outputs.version }} \
+            --build-arg GIT_COMMIT=${{ steps.version.outputs.git_commit }} \
+            --build-arg BUILD_DATE=${{ steps.version.outputs.build_date }}
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/Dockerfile.uptermd
+++ b/Dockerfile.uptermd
@@ -5,13 +5,18 @@ FROM golang:latest AS builder
 
 ARG TARGETOS
 ARG TARGETARCH
+ARG VERSION=0.0.0+dev
+ARG GIT_COMMIT=unknown
+ARG BUILD_DATE=unknown
 
 WORKDIR /src
 ENV CGO_ENABLED=0
 RUN --mount=target=. \
   --mount=type=cache,target=/root/.cache/go-build \
   --mount=type=cache,target=/go/pkg \
-  GOOS=$TARGETOS GOARCH=$TARGETARCH go install ./cmd/...
+  GOOS=$TARGETOS GOARCH=$TARGETARCH go install \
+  -ldflags="-s -w -X github.com/owenthereal/upterm/internal/version.Version=${VERSION} -X github.com/owenthereal/upterm/internal/version.GitCommit=${GIT_COMMIT} -X github.com/owenthereal/upterm/internal/version.Date=${BUILD_DATE}" \
+  ./cmd/...
 
 # Base runtime stage
 FROM gcr.io/distroless/static:nonroot AS base


### PR DESCRIPTION
The Fly.io deployment was building uptermd without version information, causing it to show 0.0.0+dev instead of the actual release version.

Changes:
- Add VERSION, GIT_COMMIT, and BUILD_DATE build args to Dockerfile.uptermd
- Inject version info via ldflags during Docker build
- Extract version from git tag in release workflow and pass as build args
- Add sensible defaults for local builds

Now deployed uptermd will correctly report its version in SSH banners (e.g., SSH-2.0-uptermd-0.15.0 instead of SSH-2.0-uptermd-0.0.0+dev)