### PR TITLE
fix `uptermRuntimeDir` when `/run/user/<uid>` does not exist

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -31,6 +31,13 @@ const (
 //   - macOS:   $TMPDIR/upterm (e.g., /var/folders/.../T/upterm)
 //   - Windows: %LOCALAPPDATA%\Temp\upterm
 func UptermRuntimeDir() string {
+	_, err := os.Stat(xdg.RuntimeDir)
+
+	if os.IsNotExist(err) {
+		// /run/user/<uid> does not exist, fallback to $HOME/.upterm
+		return filepath.Join(xdg.Home, fmt.Sprintf(".%s", appName))
+	}
+
 	return filepath.Join(xdg.RuntimeDir, appName)
 }
 


### PR DESCRIPTION

After #398 was merged, `uptermRuntimeDir()` started using uses `xdg.RuntimeDir` as base directory.

When `XDG_RUNTIME_DIR` is not set, this falls back to `/run/user/<uid>`. In some non-interactive scenarios, `/run/user/<uid>` will not be present and `upterm` won't be able to create it with `os.MkdirAll` because the user does not have permissions to write to `/run/user`, causing `upterm host` to fail.
