### PR TITLE
Fix Homebrew cask installation failure on Linux

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -75,7 +75,7 @@ homebrew_casks:
     hooks:
       post:
         install: |
-          if system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0
+          if OS.mac?
             system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/upterm"]
           end
 scoops:


### PR DESCRIPTION
Use OS.mac? check instead of attempting to run xattr to determine if quarantine removal should occur. The previous approach failed on Linux because system_command raises an error when the binary doesn't exist rather than returning a checkable exit status.

Fixes #427