### PR TITLE
README.md: docker-compose should point to the docker file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,9 @@ Below is an example `docker-compose` configuration for deploying `uptermd` behin
 ```yaml
 services:
   upterm:
-    build: https://github.com/owenthereal/upterm
+    build: 
+        context: https://github.com/owenthereal/upterm.git
+        dockerfile: Dockerfile.uptermd
     labels:
       - "traefik.enable=true"
       - "traefik.docker.network=web"


### PR DESCRIPTION
`docker compose` was not finding the docker file when using the example in the README.md.

By modifying the build step to specify the dokcerfile path, I could build and deploy the example.