### PR TITLE
Tolerate clock skew when issuing joiner user certs

### DIFF
--- a/server/cert.go
+++ b/server/cert.go
@@ -82,8 +82,14 @@ func (g *UserCertSigner) SignCert(signer ssh.Signer) (ssh.Signer, error) {
 		return nil, fmt.Errorf("error marshaling auth request: %w", err)
 	}
 
-	at := time.Now()
-	bt := at.Add(1 * time.Minute) // cert valid for 1 min
+	// Backdate ValidAfter to tolerate clock skew between the uptermd server
+	// and the host's embedded sshd (which validates this cert using its own
+	// time.Now()). Without this, a skew of even 1 second in the "server
+	// ahead of host" direction causes CheckCert to return "cert is not yet
+	// valid" on every auth attempt. See issue #151.
+	now := time.Now()
+	at := now.Add(-1 * time.Minute)
+	bt := now.Add(1 * time.Minute)
 	cert := &ssh.Certificate{
 		Key:             signer.PublicKey(),
 		CertType:        ssh.UserCert,

--- a/server/cert.go
+++ b/server/cert.go
@@ -14,6 +14,14 @@ var (
 	errCertNotSignedByHost = fmt.Errorf("ssh cert not signed by host")
 )
 
+// certClockSkewTolerance widens the user cert validity window symmetrically
+// around time.Now() so that the host's embedded sshd (which validates with
+// its own time.Now()) accepts the cert despite NTP drift between machines.
+// One minute matches step-ca's default and sits comfortably above typical
+// drift on dev environments where this fails (Docker Desktop / Rancher
+// Desktop / colima after suspend/resume). See issue #151.
+const certClockSkewTolerance = 1 * time.Minute
+
 type UserCertChecker struct {
 	UserKeyFallback func(user string, key ssh.PublicKey) (ssh.PublicKey, error)
 }
@@ -82,14 +90,9 @@ func (g *UserCertSigner) SignCert(signer ssh.Signer) (ssh.Signer, error) {
 		return nil, fmt.Errorf("error marshaling auth request: %w", err)
 	}
 
-	// Backdate ValidAfter to tolerate clock skew between the uptermd server
-	// and the host's embedded sshd (which validates this cert using its own
-	// time.Now()). Without this, a skew of even 1 second in the "server
-	// ahead of host" direction causes CheckCert to return "cert is not yet
-	// valid" on every auth attempt. See issue #151.
 	now := time.Now()
-	at := now.Add(-1 * time.Minute)
-	bt := now.Add(1 * time.Minute)
+	at := now.Add(-certClockSkewTolerance)
+	bt := now.Add(certClockSkewTolerance)
 	cert := &ssh.Certificate{
 		Key:             signer.PublicKey(),
 		CertType:        ssh.UserCert,


### PR DESCRIPTION
Fixes #151.

## Summary

`UserCertSigner.SignCert` (`server/cert.go`) mints a fresh user cert on every joiner `PublicKeyCallback` attempt with `ValidAfter = time.Now()`. Because the host's embedded sshd validates that cert with its own `time.Now()`, any positive clock skew (uptermd ahead of host) of even **one second** causes `ssh.CertChecker.CheckCert` to return `"ssh: cert is not yet valid"` — rejecting the joiner on every attempt.

The failure is hard to diagnose because:
- `sshpiper` translates the host's cert rejection into a wire-level `SSH_MSG_USERAUTH_PARTIAL_SUCCESS`
- OpenSSH then cycles through every loaded identity, each one generating the same `"cert not yet valid"` failure
- Eventually gives up with a generic `Permission denied (publickey)` — no hint at the real cause
- The true error only surfaces on the host side in `$HOME/.upterm/upterm.log` when `upterm host --debug` is used:
  ```
  "level":"ERROR","msg":"error parsing auth request from cert","error":"ssh: cert is not yet valid"
  ```

## Why this isn't just "sync your clock"

Clock skew between a macOS host and a VM-based container runtime (Docker Desktop, Rancher Desktop, Colima, OrbStack, etc.) is a well-known and recurring problem, especially after host sleep/wake. It's not something users can rely on staying within 1 second:

- [`docker/for-mac#17`](https://github.com/docker/for-mac/issues/17) — "Time drift in Moby VM and containers caused by system sleep"
- [`rancher-sandbox/rancher-desktop#7949`](https://github.com/rancher-sandbox/rancher-desktop/issues/7949) (open, Dec 2024) — 3-second drift on VZ/Apple Silicon
- [`lima-vm/lima#4527`](https://github.com/lima-vm/lima/pull/4527) — Lima added a 10s-interval host→guest time push *because* "the virtual RTC drifts together with the system clock in VZ after host sleep/wake cycles"

Even with NTP on both ends, sub-second drift between two independently-synced machines is normal. A 1-minute backdate is cheap insurance against a 60-minute debugging session for every affected user.

## Reproducer

Empirically reproduced on a self-hosted uptermd in Kubernetes with `upterm host` running in Docker Desktop on macOS. Measured:
- uptermd pod clock: 2 seconds ahead of Docker VM
- Every join attempt failed with the partial-success loop
- Once clocks drifted to within 1 second: same session, same keys — joins started succeeding

See full investigation and evidence in https://github.com/owenthereal/upterm/issues/151#issuecomment-4371748091.

## Fix

Backdate `ValidAfter` by 1 minute to match common SSH-CA convention (OpenSSH-CA, step-ca, smallstep, etc. all default to 30-60s backdating). Tolerates reasonable NTP drift in both directions.

```go
now := time.Now()
at := now.Add(-1 * time.Minute)
bt := now.Add(1 * time.Minute)
```

Tradeoffs:
- Validity window widens from 1 minute to 2 minutes — still short, still re-signed on every auth attempt
- No protocol / API change
- No new dependencies

## Test plan

- [ ] Existing tests pass (no cert-specific test file exists — behaviour covered via `sshproxy_test.go`, `sshhandler_test.go`)
- [ ] Manual verification: reproduce the skew scenario with a self-hosted uptermd whose clock is forced ahead of the host by 5s (e.g. `sudo date -u -s "+5 seconds"` in the uptermd pod); confirm join works with the patch and fails without
