### PR TITLE
Fix staticcheck SA1019 on deprecated sentryslog Option.Level

### DIFF
--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -166,9 +166,12 @@ func newSentryHandler(dsn string) (slog.Handler, func() error, error) {
 		return nil, nil, err
 	}
 
-	handler := slogsentry.Option{
-		Level: slog.LevelError,
-	}.NewSentryHandler(context.Background())
+	// Intentionally left zero-valued. Option.Level and its replacement
+	// Option.EventLevel are both deprecated, and EventLevel is slated for
+	// removal in sentry-go/slog 0.48.0. The zero value already yields
+	// EventLevel = {LevelError, LevelFatal}, which is exactly what the previous
+	// Level: slog.LevelError produced via levelsFromMinimum.
+	handler := slogsentry.Option{}.NewSentryHandler(context.Background())
 
 	cleanup := func() error {
 		ok := sentry.Flush(sentryFlushTimeout)


### PR DESCRIPTION
## Why master is red

`make vet` runs `golangci-lint:latest` in Docker, so the linter version floats. Since the sentry-go/slog v0.47.0 bump (#492) deprecated `Option.Level`, staticcheck SA1019 fires on `internal/logging/logging.go` with no change on our side:

```
internal/logging/logging.go:170:3: SA1019: (github.com/getsentry/sentry-go/slog.Option).Level
is deprecated: Use EventLevel instead. (staticcheck)
```

This turns **every open PR red**, not just new ones. Reproduced identically on `master`.

## Why not just switch to EventLevel

`EventLevel` carries its own deprecation notice and is scheduled for removal:

```go
// Deprecated: Use EventLevel instead. Level is kept for backwards compatibility...
Level slog.Leveler

// Deprecated: EventLevel creates issues/events from log entries. ...
// Use LogLevel for structured logging. Will be removed in 0.48.0.
EventLevel []slog.Level
```

Swapping one for the other just relocates the same lint error and buys a removal in the next minor.

## The fix

Drop the field. `NewSentryHandler` already applies the desired default when both fields are unset:

```go
if o.EventLevel == nil {
	if o.Level != nil {
		o.EventLevel = levelsFromMinimum(o.Level.Level())
	} else {
		o.EventLevel = []slog.Level{slog.LevelError, LevelFatal}
	}
}
```

and `levelsFromMinimum(slog.LevelError)` filters `{Debug, Info, Warn, Error, Fatal}` down to `{Error, Fatal}` — the same pair. **Behaviour-identical**, and it references no deprecated identifier. A comment records the reasoning so the field does not get helpfully restored.

## Verification

- `golangci-lint run` — 0 issues (was 1)
- `go build ./...` — clean
- `go test ./ftests/...` — pass, 41s

## Note

Worth considering pinning `golangci-lint` to a version in the Makefile rather than `latest`, so a linter release cannot turn CI red without a commit. Not done here to keep this focused.