### PR TITLE
Add session and authenticated-connection metrics to uptermd

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,7 +38,6 @@ jobs:
         run: make test
         env:
           BASH_SILENCE_DEPRECATION_WARNING: 1
-          MUTE_FLAKY_TESTS: 1
 
   test-ubuntu:
     name: Test (Ubuntu + Consul)
@@ -64,7 +63,6 @@ jobs:
         run: make test
         env:
           BASH_SILENCE_DEPRECATION_WARNING: 1
-          MUTE_FLAKY_TESTS: 1
 
   test-windows:
     name: Test (Windows)
@@ -78,8 +76,6 @@ jobs:
           check-latest: true
       - name: Test
         run: make test
-        env:
-          MUTE_FLAKY_TESTS: 1
   vet:
     name: Vet
     runs-on: ubuntu-latest

--- a/ftests/client_test.go
+++ b/ftests/client_test.go
@@ -98,8 +98,8 @@ func testClientNonExistingSession(t *testing.T, hostShareURL, hostNodeAddr, clie
 	hostScanner := scanner(hostOutputCh)
 
 	hostInputCh <- `echo "hello"`
-	require.Equal(`echo "hello"`, scan(hostScanner))
-	require.Equal("hello", scan(hostScanner))
+	expectLine(t, hostScanner, `echo "hello"`)
+	expectLine(t, hostScanner, "hello")
 
 	c := &Client{
 		PrivateKeys: []string{ClientPrivateKey},
@@ -114,7 +114,6 @@ func testClientNonExistingSession(t *testing.T, hostShareURL, hostNodeAddr, clie
 
 func testClientAttachHostWithSameCommand(t *testing.T, hostShareURL, hostNodeAddr, clientJoinURL string) {
 	require := require.New(t)
-	assert := assert.New(t)
 
 	// Setup - use require for critical setup steps
 	adminSocketFile := setupAdminSocket(t)
@@ -147,27 +146,26 @@ func testClientAttachHostWithSameCommand(t *testing.T, hostShareURL, hostNodeAdd
 
 	// host input
 	hostInputCh <- `echo "hello"`
-	assert.Equal(`echo "hello"`, scan(hostScanner), "host should echo command")
-	assert.Equal("hello", scan(hostScanner), "host should show command output")
+	expectLine(t, hostScanner, `echo "hello"`, "host should echo command")
+	expectLine(t, hostScanner, "hello", "host should show command output")
 
 	// client output
-	assert.Equal(`echo "hello"`, scan(remoteScanner), "client should see host command")
-	assert.Equal("hello", scan(remoteScanner), "client should see host output")
+	expectLine(t, remoteScanner, `echo "hello"`, "client should see host command")
+	expectLine(t, remoteScanner, "hello", "client should see host output")
 
 	// client input
 	remoteInputCh <- `echo "hello again"`
-	assert.Equal(`echo "hello again"`, scan(remoteScanner), "client should echo its own command")
-	assert.Equal("hello again", scan(remoteScanner), "client should see its own output")
+	expectLine(t, remoteScanner, `echo "hello again"`, "client should echo its own command")
+	expectLine(t, remoteScanner, "hello again", "client should see its own output")
 
 	// host output
 	// host should link to remote with the same input/output
-	assert.Equal(`echo "hello again"`, scan(hostScanner), "host should see client command")
-	assert.Equal("hello again", scan(hostScanner), "host should see client output")
+	expectLine(t, hostScanner, `echo "hello again"`, "host should see client command")
+	expectLine(t, hostScanner, "hello again", "host should see client output")
 }
 
 func testClientAttachHostWithDifferentCommand(t *testing.T, hostShareURL string, hostNodeAddr, clientJoinURL string) {
 	require := require.New(t)
-	assert := assert.New(t)
 
 	// Setup - use require for critical setup steps
 	adminSocketFile := setupAdminSocket(t)
@@ -192,9 +190,9 @@ func testClientAttachHostWithDifferentCommand(t *testing.T, hostShareURL string,
 
 	hostInputCh <- `echo "hello"`
 
-	assert.Equal(`echo "hello"`, scan(hostScanner), "host should echo initial command")
+	expectLine(t, hostScanner, `echo "hello"`, "host should echo initial command")
 
-	assert.Equal("hello", scan(hostScanner), "host should show initial output")
+	expectLine(t, hostScanner, "hello", "host should show initial output")
 
 	c := &Client{
 		PrivateKeys: []string{ClientPrivateKey},
@@ -210,19 +208,18 @@ func testClientAttachHostWithDifferentCommand(t *testing.T, hostShareURL string,
 
 	remoteInputCh <- `echo "hello again"`
 
-	assert.Equal(`echo "hello again"`, scan(remoteScanner), "client should echo its command")
-	assert.Equal("hello again", scan(remoteScanner), "client should see output")
+	expectLine(t, remoteScanner, `echo "hello again"`, "client should echo its command")
+	expectLine(t, remoteScanner, "hello again", "client should see output")
 
 	// host shouldn't be linked to remote
 	hostInputCh <- `echo "hello"`
 
-	assert.Equal(`echo "hello"`, scan(hostScanner), "host should echo second command independently")
-	assert.Equal("hello", scan(hostScanner), "host should show second output independently")
+	expectLine(t, hostScanner, `echo "hello"`, "host should echo second command independently")
+	expectLine(t, hostScanner, "hello", "host should show second output independently")
 }
 
 func testClientAttachReadOnly(t *testing.T, hostShareURL, hostNodeAddr, clientJoinURL string) {
 	require := require.New(t)
-	assert := assert.New(t)
 
 	// Setup - use require for critical setup steps
 	adminSocketFile := setupAdminSocket(t)
@@ -259,13 +256,13 @@ func testClientAttachReadOnly(t *testing.T, hostShareURL, hostNodeAddr, clientJo
 	// \n
 	// === Attached to read-only session ===
 	// \n
-	assert.Equal("=== Attached to read-only session ===", scan(remoteScanner), "client should see read-only welcome message")
+	expectLine(t, remoteScanner, "=== Attached to read-only session ===", "client should see read-only welcome message")
 
 	// host input should still work
 	hostInputCh <- `echo "hello"`
 
-	assert.Equal(`echo "hello"`, scan(hostScanner), "host should echo command in read-only mode")
-	assert.Equal("hello", scan(hostScanner), "host should show output in read-only mode")
+	expectLine(t, hostScanner, `echo "hello"`, "host should echo command in read-only mode")
+	expectLine(t, hostScanner, "hello", "host should show output in read-only mode")
 
 	// Drain any buffered output (e.g., PowerShell prompts) before testing client input blocking
 	// This prevents flaky failures where trailing shell output is mistaken for client input
@@ -284,7 +281,7 @@ func testClientAttachReadOnly(t *testing.T, hostShareURL, hostNodeAddr, clientJo
 	remoteInputCh <- `echo "hello again"`
 
 	// client should read what was sent by hostInputCh and not what was sent on remoteInputCh
-	assert.Equal(`echo "hello"`, scan(remoteScanner), "client should see host output, not its own input")
+	expectLine(t, remoteScanner, `echo "hello"`, "client should see host output, not its own input")
 
 	select {
 	// host shouldn't receive anything from client and because client input is disabled

--- a/ftests/ftests_test.go
+++ b/ftests/ftests_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/owenthereal/upterm/ws"
 	"github.com/pborman/ansi"
 	"github.com/pkg/sftp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"golang.org/x/crypto/ssh"
 )
@@ -56,7 +57,7 @@ func getTestShell() []string {
 		}
 		return []string{shell, "-NoProfile", "-NoLogo", "-NonInteractive"}
 	}
-	return []string{"bash", "-c", "PS1='' BASH_SILENCE_DEPRECATION_WARNING=1 bash --norc"}
+	return []string{"bash", "-c", "PS1='' BASH_SILENCE_DEPRECATION_WARNING=1 bash --norc --noediting"}
 }
 
 const (
@@ -124,6 +125,7 @@ var ConnectionTestCases = []FtestCase{
 // CallbackTestCases contains all callback/event-related test functions
 var CallbackTestCases = []FtestCase{
 	testHostClientCallback,
+	testHostClientCallbackReadOnly,
 	testHostSessionCreatedCallback,
 }
 
@@ -548,9 +550,15 @@ func (c *Host) Share(url string) error {
 		ForceForwardingInputForTesting: true,
 	}
 
-	errCh := make(chan error)
+	errCh := make(chan error, 1)
 	go func() {
-		if err := c.Run(c.ctx); err != nil {
+		err := c.Run(c.ctx)
+		// Nothing writes to stdout once Run has returned. Close the pipe so
+		// the output goroutine sees EOF instead of waiting for stray shell
+		// output that may never come.
+		_ = stdoutw.Close()
+		_ = stdinr.Close()
+		if err != nil {
 			testLogger.Error("error running host", "error", err)
 			errCh <- err
 		}
@@ -842,6 +850,25 @@ func stripShellPrompt(s string) string {
 	// Don't use ^ anchor so we match all occurrences, not just start of line
 	promptRe := regexp.MustCompile(`PS [^>]+>\s*`)
 	return promptRe.ReplaceAllString(s, "")
+}
+
+// expectLine reads lines until one equals want and fails the test if it does
+// not appear within a bounded number of lines. Terminals echo typed input and
+// may redraw or repeat it (readline on resize, ConPTY re-rendering), so
+// asserting an exact sequence of lines is inherently racy; skipping to the
+// expected line is not.
+func expectLine(t *testing.T, s *bufio.Scanner, want string, msgAndArgs ...interface{}) {
+	t.Helper()
+	const maxLines = 20
+	var seen []string
+	for i := 0; i < maxLines; i++ {
+		got := scan(s)
+		if got == want {
+			return
+		}
+		seen = append(seen, got)
+	}
+	assert.Fail(t, fmt.Sprintf("line %q not seen within %d lines; got %q", want, maxLines, seen), msgAndArgs...)
 }
 
 func scan(s *bufio.Scanner) string {

--- a/ftests/host_test.go
+++ b/ftests/host_test.go
@@ -2,7 +2,6 @@ package ftests
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
@@ -14,6 +13,17 @@ import (
 )
 
 func testHostClientCallback(t *testing.T, hostShareURL, hostNodeAddr, clientJoinURL string) {
+	testClientCallbacks(t, hostShareURL, hostNodeAddr, clientJoinURL, false)
+}
+
+// testHostClientCallbackReadOnly covers the read-only session path, which
+// has no input copy and so relies on the window-change channel closing to
+// learn that the client has left.
+func testHostClientCallbackReadOnly(t *testing.T, hostShareURL, hostNodeAddr, clientJoinURL string) {
+	testClientCallbacks(t, hostShareURL, hostNodeAddr, clientJoinURL, true)
+}
+
+func testClientCallbacks(t *testing.T, hostShareURL, hostNodeAddr, clientJoinURL string, readOnly bool) {
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -28,6 +38,7 @@ func testHostClientCallback(t *testing.T, hostShareURL, hostNodeAddr, clientJoin
 		PrivateKeys:              []string{HostPrivateKey},
 		AdminSocketFile:          adminSocketFile,
 		PermittedClientPublicKey: ClientPublicKeyContent,
+		ReadOnly:                 readOnly,
 		ClientJoinedCallback: func(c *api.Client) {
 			jch <- c
 		},
@@ -82,11 +93,7 @@ func testHostClientCallback(t *testing.T, hostShareURL, hostNodeAddr, clientJoin
 		assert.Equal(utils.FingerprintSHA256(pk), cc.PublicKeyFingerprint, "public key fingerprint should match on leave")
 		assert.Equal("SSH-2.0-Go", cc.Version, "client version should match on leave")
 	case <-time.After(2 * time.Second):
-		if os.Getenv("MUTE_FLAKY_TESTS") != "" {
-			testLogger.Error("FLAKY_TEST: client left callback is not called")
-		} else {
-			t.Fatal("client left callback is not called")
-		}
+		t.Fatal("client left callback is not called")
 	}
 }
 

--- a/host/internal/command.go
+++ b/host/internal/command.go
@@ -6,12 +6,62 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"sync/atomic"
+	"time"
 
 	"github.com/oklog/run"
 	"github.com/olebedev/emitter"
 	uio "github.com/owenthereal/upterm/io"
 	"golang.org/x/term"
 )
+
+const (
+	// outputIdleTimeout is how long output may stay quiet after the process
+	// exits before the pty is considered drained.
+	outputIdleTimeout = 100 * time.Millisecond
+	// outputDrainTimeout bounds the total time spent draining after exit.
+	outputDrainTimeout = time.Second
+)
+
+// activityWriter records when it last wrote, so a drain can stop once output
+// has gone idle.
+type activityWriter struct {
+	io.Writer
+	last atomic.Int64 // unix nanoseconds of the last write
+}
+
+func (w *activityWriter) Write(p []byte) (int, error) {
+	n, err := w.Writer.Write(p)
+	w.last.Store(time.Now().UnixNano())
+	return n, err
+}
+
+// waitIdle returns when done is closed, when no write has happened for idle,
+// or after max. The idle window is measured from now, not from the last
+// write, so output that has not yet been read still gets its chance.
+func (w *activityWriter) waitIdle(done <-chan struct{}, idle, max time.Duration) {
+	start := time.Now()
+	deadline := time.NewTimer(max)
+	defer deadline.Stop()
+	tick := time.NewTicker(idle / 4)
+	defer tick.Stop()
+	for {
+		select {
+		case <-done:
+			return
+		case <-deadline.C:
+			return
+		case <-tick.C:
+			last := time.Unix(0, w.last.Load())
+			if last.Before(start) {
+				last = start
+			}
+			if time.Since(last) >= idle {
+				return
+			}
+		}
+	}
+}
 
 func newCommand(
 	name string,
@@ -116,11 +166,21 @@ func (c *command) Run() error {
 			return err
 		}
 		ctx, cancel := context.WithCancel(c.ctx)
+		output := &activityWriter{Writer: c.writers}
+		done := make(chan struct{})
 		g.Add(func() error {
-			_, err := io.Copy(c.writers, uio.NewContextReader(ctx, c.ptmx))
+			defer close(done)
+			_, err := io.Copy(output, uio.NewContextReader(ctx, c.ptmx))
 			return ptyError(err)
 		}, func(err error) {
-			c.writers.Remove(os.Stdout)
+			// The process may have exited with output still buffered in the
+			// pty. Cancelling the copy here would drop it, so let the copy
+			// run until the read ends or output goes idle. On Unix the read
+			// ends by itself once the slave side closes; ConPTY never signals
+			// EOF until closed, and a background child can keep a Unix pty
+			// open, so the wait is bounded.
+			output.waitIdle(done, outputIdleTimeout, outputDrainTimeout)
+			c.writers.Remove(c.stdout)
 			cancel()
 		})
 	}

--- a/host/internal/command_test.go
+++ b/host/internal/command_test.go
@@ -2,8 +2,10 @@ package internal
 
 import (
 	"context"
+	"io"
 	"os"
 	"runtime"
+	"sync"
 	"testing"
 	"time"
 
@@ -83,10 +85,7 @@ func TestCommand_NonTTY_WithForceFlag(t *testing.T) {
 				break
 			}
 		}
-		// Only send if we captured output (don't send empty string)
-		if len(output) > 0 {
-			outputCh <- string(output)
-		}
+		outputCh <- string(output)
 	}()
 
 	// Run the command in a goroutine
@@ -120,9 +119,13 @@ func TestCommand_NonTTY_WithForceFlag(t *testing.T) {
 
 		// Verify the output shows our input was forwarded through stdin
 		_ = stdoutw.Close()
-		output := <-outputCh
-		// head -n 1 should output exactly the line we sent
-		assert.Contains(output, testInput, "should see our piped input in output, proving stdin was forwarded")
+		select {
+		case output := <-outputCh:
+			// head -n 1 should output exactly the line we sent
+			assert.Contains(output, testInput, "should see our piped input in output, proving stdin was forwarded")
+		case <-time.After(2 * time.Second):
+			assert.Fail("stdout never reached EOF")
+		}
 	case <-time.After(1500 * time.Millisecond):
 		cancel()
 		assert.Fail("command did not complete after receiving input")
@@ -196,5 +199,83 @@ func TestCommand_ContextCancellation(t *testing.T) {
 		// Command terminated successfully - reaching here proves it worked
 	case <-time.After(2 * time.Second):
 		assert.Fail("command did not terminate after context cancellation")
+	}
+}
+
+// exitedPTY models a process that has already exited with output still
+// buffered in the pty: Wait returns at once, while Read keeps returning the
+// pending chunks before EOF. On Linux and Windows the real pty behaves this
+// way; on macOS the slave write blocks until the master reads, so the race
+// cannot be reproduced with a real process.
+type exitedPTY struct {
+	mu        sync.Mutex
+	pending   [][]byte
+	closed    bool
+	readDelay time.Duration
+}
+
+func (p *exitedPTY) Read(b []byte) (int, error) {
+	time.Sleep(p.readDelay)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.closed || len(p.pending) == 0 {
+		return 0, io.EOF
+	}
+	n := copy(b, p.pending[0])
+	p.pending = p.pending[1:]
+	return n, nil
+}
+
+func (p *exitedPTY) Write(b []byte) (int, error) { return len(b), nil }
+func (p *exitedPTY) Close() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.closed = true
+	return nil
+}
+func (p *exitedPTY) Setsize(int, int) error { return nil }
+func (p *exitedPTY) Wait() error            { return nil }
+func (p *exitedPTY) Kill() error            { return nil }
+
+// TestCommand_DrainsOutputAfterExit verifies that output the process wrote
+// just before exiting is delivered rather than dropped when Run notices the
+// exit.
+func TestCommand_DrainsOutputAfterExit(t *testing.T) {
+	require := require.New(t)
+
+	stdinr, stdinw, err := os.Pipe()
+	require.NoError(err)
+	defer func() { _ = stdinr.Close() }()
+	defer func() { _ = stdinw.Close() }()
+	stdoutr, stdoutw, err := os.Pipe()
+	require.NoError(err)
+	defer func() { _ = stdoutr.Close() }()
+
+	const lastLine = "written just before exit"
+	cmd := &command{
+		stdin:   stdinr,
+		stdout:  stdoutw,
+		writers: uio.NewMultiWriter(5),
+		ctx:     context.Background(),
+		ptmx: &exitedPTY{
+			pending:   [][]byte{[]byte("first chunk\r\n"), []byte(lastLine + "\r\n")},
+			readDelay: 20 * time.Millisecond,
+		},
+	}
+
+	captured := make(chan string, 1)
+	go func() {
+		b, _ := io.ReadAll(stdoutr)
+		captured <- string(b)
+	}()
+
+	require.NoError(cmd.Run())
+	require.NoError(stdoutw.Close())
+
+	select {
+	case output := <-captured:
+		require.Contains(output, lastLine, "output buffered in the pty at exit was dropped")
+	case <-time.After(2 * time.Second):
+		t.Fatal("stdout never reached EOF")
 	}
 }

--- a/host/internal/command_unix_test.go
+++ b/host/internal/command_unix_test.go
@@ -78,10 +78,7 @@ func TestCommand_Unix_PTY(t *testing.T) {
 				break
 			}
 		}
-		// Only send if we captured output (don't send empty string)
-		if len(output) > 0 {
-			outputCh <- string(output)
-		}
+		outputCh <- string(output)
 	}()
 
 	// Run the command in a goroutine

--- a/host/internal/server.go
+++ b/host/internal/server.go
@@ -311,6 +311,17 @@ func (h *sessionHandler) HandleSession(sess gssh.Session) {
 	if h.readonly {
 		// write to client to notify them that they have connected to a read-only session
 		_, _ = io.WriteString(sess, "\r\n=== Attached to read-only session ===\r\n\r\n")
+
+		// Still read the client's input, discarding it. Reading is what
+		// tells us the client has gone (EOF), and it keeps the channel
+		// window from filling up if the client types.
+		ctx, cancel := context.WithCancel(h.ctx)
+		g.Add(func() error {
+			_, err := io.Copy(io.Discard, uio.NewContextReader(ctx, sess))
+			return err
+		}, func(err error) {
+			cancel()
+		})
 	} else {
 		// input
 		ctx, cancel := context.WithCancel(h.ctx)

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -5,6 +5,10 @@ import (
 	"net/http"
 	"sync"
 
+	"github.com/go-kit/kit/metrics"
+	kitprometheus "github.com/go-kit/kit/metrics/prometheus"
+	"github.com/go-kit/kit/metrics/provider"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -37,3 +41,90 @@ func (m *metricServer) ListenAndServe(addr string) error {
 
 	return m.server.ListenAndServe()
 }
+
+// prometheusProvider is a provider.Provider whose counters can carry labels.
+// go-kit's provider.NewPrometheusProvider registers every metric with zero
+// label names, so calling With on one of its counters panics inside
+// client_golang. Unlabeled metrics are registered exactly as go-kit does,
+// including histograms as summaries, so existing series keep their shape.
+type prometheusProvider struct {
+	namespace  string
+	subsystem  string
+	registerer prometheus.Registerer
+}
+
+func newPrometheusProvider(namespace, subsystem string, registerer prometheus.Registerer) *prometheusProvider {
+	return &prometheusProvider{
+		namespace:  namespace,
+		subsystem:  subsystem,
+		registerer: registerer,
+	}
+}
+
+// NewCounter implements provider.Provider.
+func (p *prometheusProvider) NewCounter(name string) metrics.Counter {
+	return p.NewCounterWithLabels(name)
+}
+
+// NewCounterWithLabels returns a registered counter whose With accepts the
+// given label names.
+func (p *prometheusProvider) NewCounterWithLabels(name string, labelNames ...string) metrics.Counter {
+	cv := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: p.namespace,
+		Subsystem: p.subsystem,
+		Name:      name,
+		Help:      name,
+	}, labelNames)
+	p.registerer.MustRegister(cv)
+	return kitprometheus.NewCounter(cv)
+}
+
+// NewGauge implements provider.Provider.
+func (p *prometheusProvider) NewGauge(name string) metrics.Gauge {
+	gv := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: p.namespace,
+		Subsystem: p.subsystem,
+		Name:      name,
+		Help:      name,
+	}, []string{})
+	p.registerer.MustRegister(gv)
+	return kitprometheus.NewGauge(gv)
+}
+
+// NewHistogram implements provider.Provider. Buckets are ignored, as in
+// go-kit's Prometheus provider, which exports histograms as summaries.
+func (p *prometheusProvider) NewHistogram(name string, _ int) metrics.Histogram {
+	sv := prometheus.NewSummaryVec(prometheus.SummaryOpts{
+		Namespace: p.namespace,
+		Subsystem: p.subsystem,
+		Name:      name,
+		Help:      name,
+	}, []string{})
+	p.registerer.MustRegister(sv)
+	return kitprometheus.NewSummary(sv)
+}
+
+// Stop implements provider.Provider.
+func (p *prometheusProvider) Stop() {}
+
+// newLabeledCounter returns a counter on which With(labelNames...) is honoured
+// when the provider supports labels. Otherwise it returns a plain counter that
+// drops labels, so all kinds fold into one series. Forwarding With to a
+// provider that registered zero label names, such as go-kit's own Prometheus
+// provider, would panic inside client_golang.
+func newLabeledCounter(p provider.Provider, name string, labelNames ...string) metrics.Counter {
+	if lp, ok := p.(interface {
+		NewCounterWithLabels(name string, labelNames ...string) metrics.Counter
+	}); ok {
+		return lp.NewCounterWithLabels(name, labelNames...)
+	}
+	return labelDroppingCounter{p.NewCounter(name)}
+}
+
+// labelDroppingCounter ignores With, folding every label value into the
+// underlying unlabeled counter.
+type labelDroppingCounter struct {
+	metrics.Counter
+}
+
+func (c labelDroppingCounter) With(...string) metrics.Counter { return c }

--- a/server/metrics_test.go
+++ b/server/metrics_test.go
@@ -1,0 +1,117 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/go-kit/kit/metrics/provider"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestMetrics returns a Prometheus-backed provider on a private registry so
+// tests can assert on gathered values without touching the global registry.
+func newTestMetrics(t *testing.T) (*prometheusProvider, *prometheus.Registry) {
+	t.Helper()
+	reg := prometheus.NewRegistry()
+	return newPrometheusProvider("test", "server", reg), reg
+}
+
+// gatherValue returns the value of the counter or gauge sample in family name
+// whose label set equals labels. ok is false when no such sample exists.
+func gatherValue(t *testing.T, reg *prometheus.Registry, name string, labels map[string]string) (v float64, ok bool) {
+	t.Helper()
+	families, err := reg.Gather()
+	require.NoError(t, err)
+	for _, f := range families {
+		if f.GetName() != name {
+			continue
+		}
+	metric:
+		for _, m := range f.GetMetric() {
+			if len(m.GetLabel()) != len(labels) {
+				continue
+			}
+			for _, l := range m.GetLabel() {
+				if labels[l.GetName()] != l.GetValue() {
+					continue metric
+				}
+			}
+			switch {
+			case m.GetCounter() != nil:
+				return m.GetCounter().GetValue(), true
+			case m.GetGauge() != nil:
+				return m.GetGauge().GetValue(), true
+			}
+		}
+	}
+	return 0, false
+}
+
+func Test_prometheusProvider_labeledCounter(t *testing.T) {
+	p, reg := newTestMetrics(t)
+
+	c := p.NewCounterWithLabels("labeled_count", "kind")
+	c.With("kind", "host").Add(2)
+	c.With("kind", "client").Add(1)
+
+	v, ok := gatherValue(t, reg, "test_server_labeled_count", map[string]string{"kind": "host"})
+	require.True(t, ok)
+	require.Equal(t, 2.0, v)
+
+	v, ok = gatherValue(t, reg, "test_server_labeled_count", map[string]string{"kind": "client"})
+	require.True(t, ok)
+	require.Equal(t, 1.0, v)
+}
+
+func Test_prometheusProvider_unlabeled(t *testing.T) {
+	p, reg := newTestMetrics(t)
+
+	p.NewCounter("c").Add(1)
+	p.NewGauge("g").Set(3)
+	p.NewHistogram("h", 50).Observe(1.5)
+
+	v, ok := gatherValue(t, reg, "test_server_c", nil)
+	require.True(t, ok)
+	require.Equal(t, 1.0, v)
+
+	v, ok = gatherValue(t, reg, "test_server_g", nil)
+	require.True(t, ok)
+	require.Equal(t, 3.0, v)
+
+	// Histograms are exported as summaries, matching go-kit's provider, so the
+	// existing routing_connection_duration_seconds_{sum,count} series keep
+	// their shape.
+	families, err := reg.Gather()
+	require.NoError(t, err)
+	var found bool
+	for _, f := range families {
+		if f.GetName() == "test_server_h" {
+			found = true
+			require.Equal(t, uint64(1), f.GetMetric()[0].GetSummary().GetSampleCount())
+		}
+	}
+	require.True(t, found, "summary family test_server_h not gathered")
+}
+
+func Test_newLabeledCounter(t *testing.T) {
+	// Providers without label support fall back to a plain counter; With must
+	// not panic on them.
+	c := newLabeledCounter(provider.NewDiscardProvider(), "x", "kind")
+	c.With("kind", "host").Add(1)
+
+	// Server.MetricsProvider is exported, so embedders may still pass go-kit's
+	// own Prometheus provider, whose counters panic on With. The fallback must
+	// drop the labels rather than forward them. go-kit registers on the
+	// default registerer, so swap it out for the test's lifetime.
+	defaultRegisterer := prometheus.DefaultRegisterer
+	prometheus.DefaultRegisterer = prometheus.NewRegistry()
+	t.Cleanup(func() { prometheus.DefaultRegisterer = defaultRegisterer })
+	c = newLabeledCounter(provider.NewPrometheusProvider("test", "fallback"), "labels_dropped_count", "kind")
+	c.With("kind", "host").Add(1)
+
+	p, reg := newTestMetrics(t)
+	newLabeledCounter(p, "y", "kind").With("kind", "host").Add(1)
+	v, ok := gatherValue(t, reg, "test_server_y", map[string]string{"kind": "host"})
+	require.True(t, ok)
+	require.Equal(t, 1.0, v)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/owenthereal/upterm/utils"
 	"github.com/owenthereal/upterm/ws"
 	"github.com/pires/go-proxyproto"
+	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -190,7 +191,7 @@ func Start(ctx context.Context, opt Opt, logger *slog.Logger) error {
 		if opt.MetricAddr == "" {
 			mp = provider.NewDiscardProvider()
 		} else {
-			mp = provider.NewPrometheusProvider("upterm", "uptermd")
+			mp = newPrometheusProvider("upterm", "uptermd", prometheus.DefaultRegisterer)
 		}
 
 		// Determine session routing mode
@@ -436,6 +437,7 @@ func (s *Server) ServeWithContext(ctx context.Context, sshln net.Listener, wsln 
 			HostSigners:         s.HostSigners, // TODO: use different host keys
 			NodeAddr:            s.NodeAddr,
 			SessionDialListener: sessionDialListener,
+			MetricsProvider:     s.MetricsProvider,
 			Logger:              s.Logger.With("component", "sshd"),
 		}
 		g.Add(func() error {

--- a/server/sshd.go
+++ b/server/sshd.go
@@ -8,12 +8,14 @@ import (
 	"time"
 
 	"github.com/charmbracelet/ssh"
+	"github.com/go-kit/kit/metrics"
+	"github.com/go-kit/kit/metrics/provider"
 	"github.com/owenthereal/upterm/internal/version"
 	"github.com/owenthereal/upterm/upterm"
 	"github.com/owenthereal/upterm/utils"
-	"log/slog"
 	gossh "golang.org/x/crypto/ssh"
 	"google.golang.org/protobuf/proto"
+	"log/slog"
 )
 
 var (
@@ -29,10 +31,100 @@ type sshd struct {
 	HostSigners         []gossh.Signer
 	NodeAddr            string
 	SessionDialListener SessionDialListener
+	MetricsProvider     provider.Provider
 	Logger              *slog.Logger
 
-	server *ssh.Server
-	mux    sync.Mutex
+	server   *ssh.Server
+	sessions *localSessions
+	mux      sync.Mutex
+}
+
+// localSessions tracks sessions created by this process. It drives
+// sessions_active_count and guarantees each session is deleted from the store
+// exactly once, whether the host cancels its forward or its connection ends
+// first. Sessions visible in a shared store but created on another node are
+// never touched. It is not persisted; a crash loses the count along with the
+// sessions.
+type localSessions struct {
+	gauge          metrics.Gauge
+	sessionManager *SessionManager
+	logger         *slog.Logger
+
+	mu  sync.Mutex
+	ids map[string]struct{}
+}
+
+func newLocalSessions(p provider.Provider, sessionManager *SessionManager, logger *slog.Logger) *localSessions {
+	gauge := p.NewGauge("sessions_active_count")
+	gauge.Set(0) // export the series from startup rather than from the first session
+	return &localSessions{
+		gauge:          gauge,
+		sessionManager: sessionManager,
+		logger:         logger,
+		ids:            make(map[string]struct{}),
+	}
+}
+
+func (l *localSessions) add(sessionID string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.ids[sessionID] = struct{}{}
+	l.gauge.Add(1)
+}
+
+// active reports whether sessionID was created by this process and has not
+// been ended.
+func (l *localSessions) active(sessionID string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	_, ok := l.ids[sessionID]
+	return ok
+}
+
+// end deletes sessionID from the store and releases its count. It is a no-op
+// for sessions this process did not create or has already ended. The count is
+// released even if the store delete fails: the host is gone either way.
+func (l *localSessions) end(sessionID string) {
+	l.mu.Lock()
+	_, ok := l.ids[sessionID]
+	if ok {
+		delete(l.ids, sessionID)
+		l.gauge.Add(-1)
+	}
+	// Release before touching the store: a Consul delete can be slow, and
+	// holding the lock across it would stall unrelated session creation.
+	l.mu.Unlock()
+	if !ok {
+		return
+	}
+
+	if err := l.sessionManager.DeleteSession(sessionID); err != nil {
+		l.logger.Error("error deleting session", "error", err, "session-id", sessionID)
+	}
+}
+
+// contextKeyOwnedSessions holds, per SSH connection, the set of session IDs
+// created on that connection. Forward and cancel requests are only honoured
+// for sessions the requesting connection owns.
+type contextKeyOwnedSessions struct{}
+
+func ownSession(ctx ssh.Context, sessionID string) {
+	ctx.Lock()
+	defer ctx.Unlock()
+	owned, _ := ctx.Value(contextKeyOwnedSessions{}).(map[string]struct{})
+	if owned == nil {
+		owned = make(map[string]struct{})
+		ctx.SetValue(contextKeyOwnedSessions{}, owned)
+	}
+	owned[sessionID] = struct{}{}
+}
+
+func ownsSession(ctx ssh.Context, sessionID string) bool {
+	ctx.Lock()
+	defer ctx.Unlock()
+	owned, _ := ctx.Value(contextKeyOwnedSessions{}).(map[string]struct{})
+	_, ok := owned[sessionID]
+	return ok
 }
 
 func (s *sshd) Shutdown() error {
@@ -55,12 +147,15 @@ func (s *sshd) Serve(ln net.Listener) error {
 		signers = append(signers, signer)
 	}
 
+	sessions := newLocalSessions(s.MetricsProvider, s.SessionManager, s.Logger)
 	sh := newStreamlocalForwardHandler(
 		s.SessionManager,
 		s.SessionDialListener,
+		sessions,
 		s.Logger.With("com", "stream-local-handler"),
 	)
 	s.mux.Lock()
+	s.sessions = sessions
 	s.server = &ssh.Server{
 		HostSigners: signers,
 		Handler: func(s ssh.Session) {
@@ -129,6 +224,15 @@ func (s *sshd) createSessionHandler(ctx ssh.Context, srv *ssh.Server, req *gossh
 		)
 		return false, []byte(fmt.Sprintf("failed to create session: %v", err))
 	}
+	s.sessions.add(sessionID)
+	ownSession(ctx, sessionID)
+	// The tunnel handler ends the session when the host cancels its forward.
+	// A host that disconnects before forwarding never reaches that path, so
+	// also end it when the owning connection does.
+	go func() {
+		<-ctx.Done()
+		s.sessions.end(sessionID)
+	}()
 
 	sessResp := &CreateSessionResponse{
 		SessionID: sessionID,

--- a/server/sshd_test.go
+++ b/server/sshd_test.go
@@ -7,11 +7,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/kit/metrics/provider"
 	"github.com/owenthereal/upterm/internal/logging"
 	"github.com/owenthereal/upterm/routing"
 	"github.com/owenthereal/upterm/upterm"
 	"github.com/owenthereal/upterm/utils"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -64,9 +68,10 @@ func Test_sshd_DisallowSession(t *testing.T) {
 				WithSessionManagerLogger(logger))
 			return sm
 		}(),
-		HostSigners: []ssh.Signer{signer},
-		NodeAddr:    addr,
-		Logger:      logger,
+		HostSigners:     []ssh.Signer{signer},
+		NodeAddr:        addr,
+		MetricsProvider: provider.NewDiscardProvider(),
+		Logger:          logger,
 	}
 
 	go func() {
@@ -94,4 +99,264 @@ func Test_sshd_DisallowSession(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "unsupported channel type") {
 		t.Fatalf("expect unsupported channel type error but got %v", err)
 	}
+}
+
+// testSSHD is an sshd on a loopback listener with a private metrics
+// registry and an in-memory session network.
+type testSSHD struct {
+	sshd       *sshd
+	addr       string
+	certSigner ssh.Signer
+	reg        *prometheus.Registry
+}
+
+func newTestSSHD(t *testing.T) *testSSHD {
+	t.Helper()
+	logger := logging.Must(logging.Console(), logging.Debug()).Logger
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+	addr := ln.Addr().String()
+
+	signer, err := ssh.ParsePrivateKey([]byte(TestPrivateKeyContent))
+	require.NoError(t, err)
+
+	cs := UserCertSigner{
+		SessionID: "1234",
+		User:      "owen",
+		AuthRequest: &AuthRequest{
+			ClientVersion: upterm.HostSSHClientVersion,
+			RemoteAddr:    addr,
+			AuthorizedKey: []byte(TestPublicKeyContent),
+		},
+	}
+	certSigner, err := cs.SignCert(signer)
+	require.NoError(t, err)
+
+	network := &MemoryProvider{}
+	require.NoError(t, network.SetOpts(nil))
+
+	mp, reg := newTestMetrics(t)
+	sshd := &sshd{
+		SessionManager:      newEmbeddedSessionManager(logger),
+		HostSigners:         []ssh.Signer{signer},
+		NodeAddr:            addr,
+		SessionDialListener: network.Session(),
+		MetricsProvider:     mp,
+		Logger:              logger,
+	}
+	go func() {
+		_ = sshd.Serve(ln)
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	require.NoError(t, utils.WaitForServer(ctx, addr))
+
+	return &testSSHD{sshd: sshd, addr: addr, certSigner: certSigner, reg: reg}
+}
+
+func (s *testSSHD) dial(t *testing.T) *ssh.Client {
+	t.Helper()
+	client, err := ssh.Dial("tcp", s.addr, &ssh.ClientConfig{
+		Auth:            []ssh.AuthMethod{ssh.PublicKeys(s.certSigner)},
+		User:            "owen",
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+	return client
+}
+
+func (s *testSSHD) gauge(t *testing.T) float64 {
+	t.Helper()
+	v, ok := gatherValue(t, s.reg, "test_server_sessions_active_count", nil)
+	require.True(t, ok, "sessions_active_count not exported")
+	return v
+}
+
+// createSession has the host create a session over client and returns its ID.
+func (s *testSSHD) createSession(t *testing.T, client *ssh.Client) string {
+	t.Helper()
+	reqBytes, err := proto.Marshal(&CreateSessionRequest{
+		HostUser:       "owen",
+		HostPublicKeys: [][]byte{[]byte(TestPublicKeyContent)},
+	})
+	require.NoError(t, err)
+	ok, body, err := client.SendRequest(upterm.ServerCreateSessionRequestType, true, reqBytes)
+	require.NoError(t, err)
+	require.True(t, ok, string(body))
+	var resp CreateSessionResponse
+	require.NoError(t, proto.Unmarshal(body, &resp))
+	return resp.SessionID
+}
+
+func forwardRequest(t *testing.T, client *ssh.Client, reqType, sessionID string) (bool, string) {
+	t.Helper()
+	ok, body, err := client.SendRequest(reqType, true, ssh.Marshal(&streamlocalChannelForwardMsg{SocketPath: sessionID}))
+	require.NoError(t, err)
+	return ok, string(body)
+}
+
+func Test_sshd_SessionsActiveGauge(t *testing.T) {
+	s := newTestSSHD(t)
+	require.Equal(t, 0.0, s.gauge(t), "gauge should be exported as 0 before any session")
+
+	client := s.dial(t)
+	sessionID := s.createSession(t, client)
+	require.Equal(t, 1.0, s.gauge(t), "gauge should count the created session")
+
+	// Host opens its reverse tunnel; the gauge counts sessions, not tunnels.
+	ok, body := forwardRequest(t, client, streamlocalForwardChannelType, sessionID)
+	require.True(t, ok, body)
+	require.Equal(t, 1.0, s.gauge(t))
+
+	// Host tears the tunnel down, which deletes the session.
+	ok, body = forwardRequest(t, client, cancelStreamlocalForwardChannelType, sessionID)
+	require.True(t, ok, body)
+	require.Equal(t, 0.0, s.gauge(t), "gauge should drop when the session is deleted")
+	_, err := s.sshd.SessionManager.GetSession(sessionID)
+	require.Error(t, err, "session should be deleted")
+
+	// A second cancel for the same session must not decrement again.
+	ok, _ = forwardRequest(t, client, cancelStreamlocalForwardChannelType, sessionID)
+	require.True(t, ok)
+	require.Equal(t, 0.0, s.gauge(t))
+}
+
+func Test_sshd_SessionsActiveGauge_DisconnectWithoutForward(t *testing.T) {
+	s := newTestSSHD(t)
+
+	client := s.dial(t)
+	sessionID := s.createSession(t, client)
+	require.Equal(t, 1.0, s.gauge(t))
+
+	// The host goes away before ever opening its tunnel, so no listener
+	// cleanup runs; the connection ending must still release the count and
+	// delete the session from the store.
+	require.NoError(t, client.Close())
+	require.Eventually(t, func() bool { return s.gauge(t) == 0 }, 5*time.Second, 10*time.Millisecond,
+		"gauge should drop when the owning connection ends")
+	require.Eventually(t, func() bool {
+		_, err := s.sshd.SessionManager.GetSession(sessionID)
+		return err != nil
+	}, 5*time.Second, 10*time.Millisecond, "session should be deleted when the owning connection ends")
+}
+
+func Test_sshd_ForwardRequiresActiveSession(t *testing.T) {
+	s := newTestSSHD(t)
+
+	client := s.dial(t)
+	sessionID := s.createSession(t, client)
+	ok, body := forwardRequest(t, client, streamlocalForwardChannelType, sessionID)
+	require.True(t, ok, body)
+	ok, body = forwardRequest(t, client, cancelStreamlocalForwardChannelType, sessionID)
+	require.True(t, ok, body)
+	require.Equal(t, 0.0, s.gauge(t))
+
+	// If the store delete had failed, the record would still be there while
+	// the session is no longer counted. The connection still owns the ID, so
+	// ownership alone must not be enough to reopen the tunnel.
+	sess, err := s.sshd.SessionManager.GetSession(sessionID)
+	require.Error(t, err)
+	require.Nil(t, sess)
+	_, err = s.sshd.SessionManager.CreateSession(NewSession(sessionID, s.addr, "owen", nil, nil))
+	require.NoError(t, err)
+
+	ok, _ = forwardRequest(t, client, streamlocalForwardChannelType, sessionID)
+	require.False(t, ok, "forward of an ended session must be rejected")
+	require.Equal(t, 0.0, s.gauge(t))
+}
+
+func Test_sshd_ForwardRequiresSessionOwnership(t *testing.T) {
+	s := newTestSSHD(t)
+
+	// A session created on another node is visible in a shared store but
+	// belongs to a connection this node never saw.
+	foreign := NewSession("foreign-session", "other-node:22", "owen", nil, nil)
+	_, err := s.sshd.SessionManager.CreateSession(foreign)
+	require.NoError(t, err)
+
+	owner := s.dial(t)
+	other := s.dial(t)
+	sessionID := s.createSession(t, owner)
+	require.Equal(t, 1.0, s.gauge(t))
+
+	for name, id := range map[string]string{"foreign node": foreign.ID, "other connection": sessionID} {
+		t.Run(name, func(t *testing.T) {
+			ok, _ := forwardRequest(t, other, streamlocalForwardChannelType, id)
+			require.False(t, ok, "forward of a session not created on this connection must be rejected")
+			ok, _ = forwardRequest(t, other, cancelStreamlocalForwardChannelType, id)
+			require.False(t, ok, "cancel of a session not created on this connection must be rejected")
+			_, err := s.sshd.SessionManager.GetSession(id)
+			require.NoError(t, err, "rejected requests must not delete the session")
+			require.Equal(t, 1.0, s.gauge(t))
+		})
+	}
+
+	// The creating connection can still forward and cancel its own session.
+	ok, body := forwardRequest(t, owner, streamlocalForwardChannelType, sessionID)
+	require.True(t, ok, body)
+	ok, body = forwardRequest(t, owner, cancelStreamlocalForwardChannelType, sessionID)
+	require.True(t, ok, body)
+	_, err = s.sshd.SessionManager.GetSession(sessionID)
+	require.Error(t, err)
+	require.Equal(t, 0.0, s.gauge(t))
+}
+
+// blockingDeleteStore signals on entered when Delete is called, then holds
+// the call until release is closed.
+type blockingDeleteStore struct {
+	SessionStore
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (s blockingDeleteStore) Delete(sessionID string) error {
+	close(s.entered)
+	<-s.release
+	return s.SessionStore.Delete(sessionID)
+}
+
+func Test_localSessions_SlowDeleteDoesNotBlockAdd(t *testing.T) {
+	logger := logging.Must(logging.Console(), logging.Debug()).Logger
+	store := blockingDeleteStore{
+		SessionStore: newMemorySessionStore(logger),
+		entered:      make(chan struct{}),
+		release:      make(chan struct{}),
+	}
+	sm := newSessionManagerWithStore(store, routing.NewEncodeDecoder(routing.ModeEmbedded))
+	mp, reg := newTestMetrics(t)
+	sessions := newLocalSessions(mp, sm, logger)
+
+	_, err := sm.CreateSession(NewSession("slow", "node", "owen", nil, nil))
+	require.NoError(t, err)
+	sessions.add("slow")
+
+	ended := make(chan struct{})
+	go func() {
+		sessions.end("slow")
+		close(ended)
+	}()
+	<-store.entered // end is now inside the store delete
+
+	// A Consul delete can take a while; other hosts creating sessions must
+	// not queue behind it.
+	added := make(chan struct{})
+	go func() {
+		sessions.add("other")
+		close(added)
+	}()
+	select {
+	case <-added:
+	case <-time.After(2 * time.Second):
+		t.Fatal("add blocked behind a slow delete")
+	}
+
+	close(store.release)
+	<-ended
+	v, ok := gatherValue(t, reg, "test_server_sessions_active_count", nil)
+	require.True(t, ok)
+	require.Equal(t, 1.0, v)
 }

--- a/server/sshd_test.go
+++ b/server/sshd_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"io"
 	"net"
 	"strings"
 	"testing"
@@ -108,6 +109,7 @@ type testSSHD struct {
 	addr       string
 	certSigner ssh.Signer
 	reg        *prometheus.Registry
+	network    *MemoryProvider
 }
 
 func newTestSSHD(t *testing.T) *testSSHD {
@@ -154,7 +156,7 @@ func newTestSSHD(t *testing.T) *testSSHD {
 	defer cancel()
 	require.NoError(t, utils.WaitForServer(ctx, addr))
 
-	return &testSSHD{sshd: sshd, addr: addr, certSigner: certSigner, reg: reg}
+	return &testSSHD{sshd: sshd, addr: addr, certSigner: certSigner, reg: reg, network: network}
 }
 
 func (s *testSSHD) dial(t *testing.T) *ssh.Client {
@@ -359,4 +361,43 @@ func Test_localSessions_SlowDeleteDoesNotBlockAdd(t *testing.T) {
 	v, ok := gatherValue(t, reg, "test_server_sessions_active_count", nil)
 	require.True(t, ok)
 	require.Equal(t, 1.0, v)
+}
+
+func Test_sshd_ClosesTunnelChannelWhenGuestLeaves(t *testing.T) {
+	s := newTestSSHD(t)
+
+	client := s.dial(t)
+	incoming := client.HandleChannelOpen(forwardedStreamlocalChannelType)
+	sessionID := s.createSession(t, client)
+	ok, body := forwardRequest(t, client, streamlocalForwardChannelType, sessionID)
+	require.True(t, ok, body)
+
+	// The relay dials the session socket on a guest's behalf, which opens a
+	// forwarded channel to the host.
+	guest, err := s.network.Session().Dial(sessionID)
+	require.NoError(t, err)
+	var newCh ssh.NewChannel
+	select {
+	case newCh = <-incoming:
+	case <-time.After(5 * time.Second):
+		t.Fatal("host never received the forwarded channel")
+	}
+	ch, reqs, err := newCh.Accept()
+	require.NoError(t, err)
+	go ssh.DiscardRequests(reqs)
+
+	// The guest goes away. The host must learn of it without having to
+	// write anything first: that is what drives its client-left event.
+	require.NoError(t, guest.Close())
+	read := make(chan error, 1)
+	go func() {
+		_, err := ch.Read(make([]byte, 1))
+		read <- err
+	}()
+	select {
+	case err := <-read:
+		require.ErrorIs(t, err, io.EOF)
+	case <-time.After(2 * time.Second):
+		t.Fatal("channel stayed open after the guest disconnected")
+	}
 }

--- a/server/sshhandler.go
+++ b/server/sshhandler.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/charmbracelet/ssh"
 	"github.com/oklog/run"
-	"log/slog"
 	gossh "golang.org/x/crypto/ssh"
+	"log/slog"
 )
 
 const (
@@ -66,11 +66,13 @@ func isExpectedShutdownError(err error) bool {
 func newStreamlocalForwardHandler(
 	sessionManager *SessionManager,
 	sessionDialListener SessionDialListener,
+	sessions *localSessions,
 	logger *slog.Logger,
 ) *streamlocalForwardHandler {
 	return &streamlocalForwardHandler{
 		sessionManager:      sessionManager,
 		sessionDialListener: sessionDialListener,
+		sessions:            sessions,
 		forwards:            make(map[string]net.Listener),
 		logger:              logger,
 	}
@@ -79,6 +81,7 @@ func newStreamlocalForwardHandler(
 type streamlocalForwardHandler struct {
 	sessionManager      *SessionManager
 	sessionDialListener SessionDialListener
+	sessions            *localSessions
 	forwards            map[string]net.Listener
 	logger              *slog.Logger
 	sync.Mutex
@@ -182,7 +185,19 @@ func (h *streamlocalForwardHandler) Handler(ctx ssh.Context, srv *ssh.Server, re
 		sessionID := reqPayload.SocketPath
 		logger := h.logger.With("session-id", sessionID)
 
-		// validate session exists
+		// Only the connection that created a session may open its tunnel,
+		// and only while the session is still active here. The store is
+		// shared across nodes, so existence alone proves nothing about who
+		// is asking; and an ended session whose store delete failed must not
+		// be reopened uncounted.
+		if !ownsSession(ctx, sessionID) {
+			logger.Warn("rejected forward for session not created on this connection")
+			return false, []byte("session not created on this connection")
+		}
+		if !h.sessions.active(sessionID) {
+			logger.Warn("rejected forward for ended session")
+			return false, []byte("session has ended")
+		}
 		if _, err := h.sessionManager.GetSession(sessionID); err != nil {
 			return false, []byte(err.Error())
 		}
@@ -232,6 +247,10 @@ func (h *streamlocalForwardHandler) Handler(ctx ssh.Context, srv *ssh.Server, re
 		}
 
 		sessionID := reqPayload.SocketPath
+		if !ownsSession(ctx, sessionID) {
+			h.logger.Warn("rejected cancel for session not created on this connection", "session-id", sessionID)
+			return false, []byte("session not created on this connection")
+		}
 		h.closeListener(sessionID)
 
 		return true, nil
@@ -267,7 +286,5 @@ func (h *streamlocalForwardHandler) closeListener(sessionID string) {
 
 	delete(h.forwards, sessionID)
 
-	if err := h.sessionManager.DeleteSession(sessionID); err != nil {
-		logger.Error("error deleting session", "error", err)
-	}
+	h.sessions.end(sessionID)
 }

--- a/server/sshhandler.go
+++ b/server/sshhandler.go
@@ -122,6 +122,14 @@ func (h *streamlocalForwardHandler) handleConnection(ctx ssh.Context, conn *goss
 		}
 	}()
 
+	// Whichever side finishes first, close both. Without this, a guest
+	// disconnecting leaves the channel to the host open until the host next
+	// writes output, so the host cannot tell that the guest has left.
+	closeBoth := func(error) {
+		_ = localConn.Close()
+		_ = ch.Close()
+	}
+
 	var g run.Group
 
 	// Context cancellation handler
@@ -129,9 +137,7 @@ func (h *streamlocalForwardHandler) handleConnection(ctx ssh.Context, conn *goss
 		g.Add(func() error {
 			<-ctx.Done()
 			return ctx.Err()
-		}, func(err error) {
-			// Context cancelled, close all connections
-		})
+		}, closeBoth)
 	}
 
 	// SSH request handler
@@ -139,9 +145,7 @@ func (h *streamlocalForwardHandler) handleConnection(ctx ssh.Context, conn *goss
 		g.Add(func() error {
 			gossh.DiscardRequests(reqs)
 			return nil
-		}, func(err error) {
-			// Requests handler stopped
-		})
+		}, closeBoth)
 	}
 
 	// Copy from local to SSH channel
@@ -149,9 +153,7 @@ func (h *streamlocalForwardHandler) handleConnection(ctx ssh.Context, conn *goss
 		g.Add(func() error {
 			_, err := io.Copy(ch, localConn)
 			return err
-		}, func(err error) {
-			// Copy stopped
-		})
+		}, closeBoth)
 	}
 
 	// Copy from SSH channel to local
@@ -159,12 +161,10 @@ func (h *streamlocalForwardHandler) handleConnection(ctx ssh.Context, conn *goss
 		g.Add(func() error {
 			_, err := io.Copy(localConn, ch)
 			return err
-		}, func(err error) {
-			// Copy stopped
-		})
+		}, closeBoth)
 	}
 
-	if err := g.Run(); err != nil && err != context.Canceled {
+	if err := g.Run(); err != nil && err != context.Canceled && !isExpectedShutdownError(err) {
 		logger.Error("error handling connection", "error", err)
 	}
 }

--- a/server/sshproxy_test.go
+++ b/server/sshproxy_test.go
@@ -3,6 +3,8 @@ package server
 import (
 	"context"
 	"crypto/rand"
+	"errors"
+	"io"
 	"net"
 	"os"
 	"path/filepath"
@@ -56,6 +58,7 @@ func Test_sshProxy_dialUpstream(t *testing.T) {
 	}()
 
 	proxyAddr := proxyLn.Addr().String()
+	mp, reg := newTestMetrics(t)
 	cd := sidewayConnDialer{
 		NodeAddr:        proxyAddr,
 		NeighbourDialer: tcpConnDialer{},
@@ -68,7 +71,7 @@ func Test_sshProxy_dialUpstream(t *testing.T) {
 		NodeAddr:        proxyAddr,
 		ConnDialer:      cd,
 		Logger:          logger,
-		MetricsProvider: provider.NewDiscardProvider(),
+		MetricsProvider: mp,
 	}
 
 	go func() {
@@ -92,10 +95,11 @@ func Test_sshProxy_dialUpstream(t *testing.T) {
 
 	sshdAddr := sshLn.Addr().String()
 	sshd := &sshd{
-		SessionManager: newEmbeddedSessionManager(logger),
-		HostSigners:    []ssh.Signer{signer},
-		NodeAddr:       sshdAddr,
-		Logger:         logger,
+		SessionManager:  newEmbeddedSessionManager(logger),
+		HostSigners:     []ssh.Signer{signer},
+		NodeAddr:        sshdAddr,
+		MetricsProvider: provider.NewDiscardProvider(),
+		Logger:          logger,
 	}
 
 	go func() {
@@ -146,6 +150,37 @@ func Test_sshProxy_dialUpstream(t *testing.T) {
 			}
 		})
 	}
+
+	// Both cases authenticated as clients (non-host SSH client version) and
+	// none as hosts.
+	const authenticated = "test_server_routing_authenticated_connections_count"
+	v, ok := gatherValue(t, reg, authenticated, map[string]string{"kind": "client"})
+	require.True(t, ok)
+	require.Equal(t, float64(len(cases)), v)
+	v, ok = gatherValue(t, reg, authenticated, map[string]string{"kind": "host"})
+	require.True(t, ok, "host series should be exported even at zero")
+	require.Equal(t, 0.0, v)
+
+	// A client that answers the server's key query but never signs runs
+	// PublicKeyCallback yet fails authentication; it must not be counted.
+	_, err = ssh.Dial("tcp", proxyAddr, &ssh.ClientConfig{
+		User:            user,
+		Auth:            []ssh.AuthMethod{ssh.PublicKeys(refusingSigner{signer})},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	})
+	require.Error(t, err)
+	v, ok = gatherValue(t, reg, authenticated, map[string]string{"kind": "client"})
+	require.True(t, ok)
+	require.Equal(t, float64(len(cases)), v, "failed authentication must not be counted")
+}
+
+// refusingSigner presents a public key but refuses to sign with it.
+type refusingSigner struct {
+	ssh.Signer
+}
+
+func (s refusingSigner) Sign(io.Reader, []byte) (*ssh.Signature, error) {
+	return nil, errors.New("refused to sign")
 }
 
 func testCertSigner(user string, signer ssh.Signer) (ssh.Signer, error) {

--- a/server/sshrouting.go
+++ b/server/sshrouting.go
@@ -39,16 +39,28 @@ type routingInstruments struct {
 	connectionDuration metrics.Histogram
 	errors             metrics.Counter
 	connectionTimeouts metrics.Counter
+	// authenticatedHost and authenticatedClient count connections whose
+	// downstream and upstream authentication both completed, split by what
+	// connected. connections counts every accepted TCP connection, scanners
+	// included.
+	authenticatedHost   metrics.Counter
+	authenticatedClient metrics.Counter
 }
 
 func newSSHRoutingInstruments(p provider.Provider) *routingInstruments {
-	return &routingInstruments{
-		connections:        p.NewCounter("routing_connections_count"),
-		errors:             p.NewCounter("routing_errors_count"),
-		activeConnections:  p.NewGauge("routing_active_connections_count"),
-		connectionDuration: p.NewHistogram("routing_connection_duration_seconds", 50),
-		connectionTimeouts: p.NewCounter("routing_connection_timeout_count"),
+	authenticated := newLabeledCounter(p, "routing_authenticated_connections_count", "kind")
+	inst := &routingInstruments{
+		connections:         p.NewCounter("routing_connections_count"),
+		errors:              p.NewCounter("routing_errors_count"),
+		activeConnections:   p.NewGauge("routing_active_connections_count"),
+		connectionDuration:  p.NewHistogram("routing_connection_duration_seconds", 50),
+		connectionTimeouts:  p.NewCounter("routing_connection_timeout_count"),
+		authenticatedHost:   authenticated.With("kind", "host"),
+		authenticatedClient: authenticated.With("kind", "client"),
 	}
+	inst.authenticatedHost.Add(0) // export both series from startup
+	inst.authenticatedClient.Add(0)
+	return inst
 }
 
 func (p *SSHRouting) Serve(ln net.Listener) error {
@@ -157,6 +169,15 @@ func (p *SSHRouting) Serve(ln net.Listener) error {
 			select {
 			case pconn := <-pipec:
 				defer pconn.Close()
+
+				// NewSSHPiperConn returns only once both sides have
+				// authenticated. PublicKeyCallback is too early: the
+				// server also invokes it for unsigned key queries.
+				if string(pconn.DownstreamConnMeta().ClientVersion()) == upterm.HostSSHClientVersion {
+					inst.authenticatedHost.Add(1)
+				} else {
+					inst.authenticatedClient.Add(1)
+				}
 
 				if err := pconn.Wait(); err != nil {
 					logger.Debug("error waiting for pipe", "error", err)


### PR DESCRIPTION
Sizing the E2E port range and the abuse rate limits needs two numbers the
relay does not report today: how many sessions are live, and how many
accepted connections actually authenticate. The existing
`routing_active_connections_count` conflates hosts, guests, scanners and
cross-node hops.

## New metrics

- `upterm_uptermd_sessions_active_count` — sessions created by this node
  whose host connection is still open. `sshd` gains a `MetricsProvider`.
  Sessions are tracked in `localSessions` and ended exactly once, on
  whichever comes first of the host cancelling its forward or its
  connection closing.
- `upterm_uptermd_routing_authenticated_connections_count{kind="host"|"client"}`
  — counted once `NewSSHPiperConn` returns, the first point where both
  sides have authenticated. `PublicKeyCallback` is too early: the server
  also invokes it for unsigned key queries, so a client that never signs
  would be counted.

Both series are exported at zero from startup. The existing routing gauge
is unchanged.

## Provider

go-kit's Prometheus provider registers every metric with zero label
names, so `Counter.With` on one of its counters panics inside
client_golang. `server/metrics.go` adds a provider whose counters accept
labels. Unlabeled metrics keep exactly the same shape as before, including
histograms exported as summaries. Providers without label support fold
all kinds into one series rather than panicking.

## Session lifecycle fixes

Two pre-existing bugs are fixed because the gauge depends on them:

- A host that disconnected before opening its tunnel leaked its session
  record. It is now deleted when the owning connection ends.
- Any host could forward or cancel a session it did not create, including
  one belonging to another node in a shared store, which also let it
  delete that session and block the real owner from binding its socket.
  Forward and cancel now require that the requesting connection created
  the session and that it is still active on this node.

Session deletion no longer runs under the tracker's lock, so a slow Consul
delete cannot stall unrelated session creation.

## Wire compatibility

Nothing on the wire changes. Old hosts, old guests and old self-hosted
relays are unaffected.

## Testing

- `go test ./server/ -race -count=2`, `go vet`, `golangci-lint`: clean.
- New tests drive a real SSH connection through create → forward →
  cancel, disconnect without forward, foreign-session and cross-connection
  forwards, reforward after cancel, a signer that refuses to sign, and a
  store whose delete blocks.
- `go test ./ftests/` passes. `TestCallbacks/testHostClientCallback`
  flakes on this branch and on master at a similar rate; it is the
  client-left timeout that CI already mutes via `MUTE_FLAKY_TESTS`.
