### PR TITLE
Stop generating Homebrew's deprecated `postflight` stanza

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -76,12 +76,20 @@ homebrew_casks:
     completions:
       bash: "etc/completion/upterm.bash_completion.sh"
       zsh: "etc/completion/upterm.zsh_completion"
-    hooks:
-      post:
-        install: |
-          if OS.mac?
-            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/upterm"]
-          end
+    # Strip the macOS quarantine attribute so Gatekeeper does not block the
+    # unsigned binary. Homebrew deprecated the `postflight` stanza that
+    # `hooks.post.install` generates, so emit `postflight_steps` by hand until
+    # GoReleaser grows `hooks.post.install_steps`. Once that ships, replace this
+    # with the hook so the stanza lands in the right place in the Cask.
+    # See https://github.com/goreleaser/goreleaser/pull/6873
+    # The inner braces are escaped so GoReleaser leaves Homebrew's
+    # `{{staged_path}}` token for Homebrew to expand.
+    custom_block: |
+      postflight_steps do
+        on_macos do
+          run "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "{{ `{{staged_path}}` }}/upterm"]
+        end
+      end
 scoops:
   - repository:
       owner: owenthereal

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ export PATH := $(BIN_DIR):$(PATH)
 tools:
 	rm -rf $(BIN_DIR) && mkdir -p $(BIN_DIR)
 	# goreleaser
-	GOBIN=$(BIN_DIR) go install github.com/goreleaser/goreleaser@latest
+	GOBIN=$(BIN_DIR) go install github.com/goreleaser/goreleaser/v2@latest
 
 .PHONY: generate
 generate: proto


### PR DESCRIPTION
Homebrew deprecated the `postflight` Cask stanza in favour of `postflight_steps`, so every `brew` operation against the tap now prints:

```
Warning: Calling `postflight` is deprecated! Use `postflight_steps` instead.
Please report this issue to the owenthereal/homebrew-upterm tap (not Homebrew/* repositories), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/owenthereal/homebrew-upterm/Casks/upterm.rb:48
```

## Why `custom_block` and not `hooks`

GoReleaser hardcodes `postflight do` in its Cask template, so `hooks.post.install` cannot emit the replacement. Upstream is adding `hooks.post.install_steps` in [goreleaser/goreleaser#6873](https://github.com/goreleaser/goreleaser/pull/6873), but it is unmerged and not in 2.18.1 or the 2.19 nightly. `custom_block` is the only way to write the stanza today.

The tradeoff: `custom_block` renders at the top of the Cask, so `postflight_steps` lands before `version`, out of Cask stanza order. That is cosmetic — only `brew audit --strict` / `brew style` would flag it, and neither runs against a third-party tap on install. The config comment points at the upstream PR so this reverts to the hook once 2.19 ships.

## The body had to change shape

`postflight_steps` takes Homebrew's declarative install-steps DSL, not arbitrary Ruby. So `if OS.mac?` becomes `on_macos`, `system_command` becomes `run`, and `#{staged_path}` becomes the `{{staged_path}}` template token (double-escaped in the config so GoReleaser passes it through to Homebrew).

Generated Cask:

```ruby
cask "upterm" do
  postflight_steps do
    on_macos do
      run "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "{{staged_path}}/upterm"]
    end
  end

  version "0.24.0"
  ...
```

## Also: `make tools` installed GoReleaser v1

`go install github.com/goreleaser/goreleaser@latest` is the v1 module path and resolves to **v1.26.2**, which cannot read a `version: 2` config. Fixed to `/v2@latest`.

## Verification

- Snapshot release run generates the Cask with `postflight_steps` and no `postflight`.
- Loaded that Cask in a scratch tap: parses with no deprecation warning. The old form reproduced the warning in the same harness, so the test detects it.
- Real `brew install --cask` against a local `file://` tarball: Homebrew propagated `com.apple.quarantine` to the staged dir, ran `Cask::Artifact::PostflightSteps`, and `xattr -p com.apple.quarantine` afterwards returned `No such xattr`.
- `make tools && ./bin/goreleaser check` → v2.18.1, config validates.
- Full snapshot release emits no other deprecation warnings; `goreleaser check` is clean on 2.18.1 and the 2.19 nightly.
