### PR TITLE
Prepare for the sshpiper removal: drop the sftp replace, characterization tests, exit-status and charm.land/ssh fixes

### DIFF
--- a/ftests/host_test.go
+++ b/ftests/host_test.go
@@ -103,6 +103,18 @@ func testClientCallbacks(t *testing.T, hostShareURL, hostNodeAddr, clientJoinURL
 	err = c.JoinWithContext(ctx, session, clientJoinURL)
 	require.NoError(err)
 
+	// Drain the guest's output. Client.JoinWithContext pumps the session into
+	// an unbuffered channel, so a test that never reads it stops the guest
+	// reading its SSH channel, the channel window fills, and the host blocks
+	// writing to it. This test does not care what the shell prints, but
+	// leaving it unread makes the host's output fan-out the slowest part of
+	// the system for no reason.
+	_, remoteOutputCh := c.InputOutput()
+	go func() {
+		for range remoteOutputCh { //nolint:revive // drained, not inspected
+		}
+	}()
+
 	pk, _, _, _, err := ssh.ParseAuthorizedKey([]byte(ClientPublicKeyContent))
 	require.NoError(err)
 

--- a/ftests/host_test.go
+++ b/ftests/host_test.go
@@ -1,7 +1,9 @@
 package ftests
 
 import (
+	"bytes"
 	"context"
+	"runtime/pprof"
 	"testing"
 	"time"
 
@@ -11,6 +13,38 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
 )
+
+// callbackTimeout bounds how long a test waits for a host callback that is
+// causally downstream of an action the test has already taken. Measured on the
+// happy path, the client-left callback fires ~600µs after Client.Close()
+// returns, so this ceiling is four orders of magnitude of headroom: it costs
+// nothing when the callback fires and keeps the assertion about *whether* the
+// event happened rather than about how loaded the machine is.
+//
+// It replaces a 2s budget that failed roughly one full-suite run in five on
+// testHostClientCallback. A flaky baseline is worse than a slow one here,
+// because the functional suite is the safety net for the front-door rewrite,
+// and a failure that cannot be trusted is not a safety net.
+const callbackTimeout = 10 * time.Second
+
+// awaitClientCallback waits for a client event, dumping goroutine stacks if it
+// never arrives. A bare "callback is not called" says nothing about whether the
+// event was dropped, the host's event loop wedged, or the relay never tore the
+// connection down; the stacks say which.
+func awaitClientCallback(t *testing.T, ch <-chan *api.Client, what string) *api.Client {
+	t.Helper()
+
+	select {
+	case c := <-ch:
+		return c
+	case <-time.After(callbackTimeout):
+		var stacks bytes.Buffer
+		_ = pprof.Lookup("goroutine").WriteTo(&stacks, 2)
+		t.Logf("goroutine dump at %s callback timeout:\n%s", what, stacks.String())
+		t.Fatalf("client %s callback was not called within %s", what, callbackTimeout)
+		return nil
+	}
+}
 
 func testHostClientCallback(t *testing.T, hostShareURL, hostNodeAddr, clientJoinURL string) {
 	testClientCallbacks(t, hostShareURL, hostNodeAddr, clientJoinURL, false)
@@ -27,8 +61,14 @@ func testClientCallbacks(t *testing.T, hostShareURL, hostNodeAddr, clientJoinURL
 	require := require.New(t)
 	assert := assert.New(t)
 
-	jch := make(chan *api.Client)
-	lch := make(chan *api.Client)
+	// Buffered so a duplicate event cannot wedge the host. The emitter
+	// delivers to listeners from a goroutine that holds an emitter-wide lock
+	// while it blocks on the listener channel, so one callback stuck on an
+	// unbuffered send stalls every later event on that host, including the
+	// client-left event this test is waiting for. The spare capacity also
+	// lets the test observe duplicates instead of deadlocking on them.
+	jch := make(chan *api.Client, 4)
+	lch := make(chan *api.Client, 4)
 
 	// Setup admin socket
 	adminSocketFile := setupAdminSocket(t)
@@ -63,38 +103,30 @@ func testClientCallbacks(t *testing.T, hostShareURL, hostNodeAddr, clientJoinURL
 	err = c.JoinWithContext(ctx, session, clientJoinURL)
 	require.NoError(err)
 
-	var clientID string
-	select {
-	case cc := <-jch:
-		pk, _, _, _, err := ssh.ParseAuthorizedKey([]byte(ClientPublicKeyContent))
-		require.NoError(err)
+	pk, _, _, _, err := ssh.ParseAuthorizedKey([]byte(ClientPublicKeyContent))
+	require.NoError(err)
 
-		assert.NotEmpty(cc.Id, "client id can't be empty")
-		clientID = cc.Id
-
-		assert.Equal(utils.FingerprintSHA256(pk), cc.PublicKeyFingerprint, "public key fingerprint should match")
-		assert.Equal("SSH-2.0-Go", cc.Version, "client version should match")
-	case <-time.After(2 * time.Second):
-		t.Fatal("client joined callback is not called")
-	}
+	joined := awaitClientCallback(t, jch, "joined")
+	assert.NotEmpty(joined.Id, "client id can't be empty")
+	assert.Equal(utils.FingerprintSHA256(pk), joined.PublicKeyFingerprint, "public key fingerprint should match")
+	assert.Equal("SSH-2.0-Go", joined.Version, "client version should match")
 
 	// client leaves
 	cancel()
 	c.Close()
 
-	select {
-	case cc := <-lch:
-		assert.NotEmpty(cc.Id, "client id can't be empty")
+	left := awaitClientCallback(t, lch, "left")
+	assert.NotEmpty(left.Id, "client id can't be empty")
+	assert.Equal(joined.Id, left.Id, "client ID should match on leave")
+	assert.Equal(utils.FingerprintSHA256(pk), left.PublicKeyFingerprint, "public key fingerprint should match on leave")
+	assert.Equal("SSH-2.0-Go", left.Version, "client version should match on leave")
 
-		pk, _, _, _, err := ssh.ParseAuthorizedKey([]byte(ClientPublicKeyContent))
-		require.NoError(err)
-
-		assert.Equal(clientID, cc.Id, "client ID should match on leave")
-		assert.Equal(utils.FingerprintSHA256(pk), cc.PublicKeyFingerprint, "public key fingerprint should match on leave")
-		assert.Equal("SSH-2.0-Go", cc.Version, "client version should match on leave")
-	case <-time.After(2 * time.Second):
-		t.Fatal("client left callback is not called")
-	}
+	// Exactly one event of each kind per guest. The relay terminates SSH on
+	// both sides, so a change to how it originates connections upstream can
+	// easily make the host see a guest join or leave twice; today it does not.
+	// These can only fire on a real duplicate, never on a slow machine.
+	assert.Empty(jch, "expected exactly one client joined event")
+	assert.Empty(lch, "expected exactly one client left event")
 }
 
 func testHostSessionCreatedCallback(t *testing.T, hostShareURL, hostNodeAddr, clientJoinURL string) {

--- a/ftests/proxy_test.go
+++ b/ftests/proxy_test.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"crypto/rand"
 	"encoding/base64"
-	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -172,16 +171,14 @@ func testProxyExitStatus(t *testing.T, hostShareURL, hostNodeAddr, clientJoinURL
 		"output written before the exit status should not be truncated by the close")
 }
 
-// testProxyForcedCommandExitStatus pins that a forced command's termination is
-// reported to the guest at all.
+// testProxyForcedCommandExitStatus pins that a forced command's exit code
+// reaches the guest.
 //
-// The exit *code* is deliberately not asserted. upterm's host races the forced
-// command's Wait against the pty's EOF in a run.Group and reports whichever
-// lands first, so the guest sees the command's real code or a clean 0
-// depending on scheduling (host/internal/server.go, HandleSession). That is a
-// host-side defect, unrelated to the relay, and pinning it here would make
-// this test flaky. What the relay owes the guest is that *an* exit status
-// arrives before the channel closes, which is what this asserts.
+// This is the realistic shape of the exit-status hazard, and the case Expo's
+// join.sh runs. It is also a regression test for the host: HandleSession used
+// to read the status off run.Group's return value, which reports whichever
+// actor finished first, so the command's wait raced the pty's EOF and the
+// guest saw 42 or a clean 0 depending on scheduling.
 func testProxyForcedCommandExitStatus(t *testing.T, hostShareURL, hostNodeAddr, clientJoinURL string) {
 	const wantCode = 42
 
@@ -218,10 +215,8 @@ func testProxyForcedCommandExitStatus(t *testing.T, hostShareURL, hostNodeAddr, 
 		"guest received no exit-status before the channel closed")
 
 	var exitErr *ssh.ExitError
-	if errors.As(err, &exitErr) {
-		t.Logf("forced command exit status: %d (host reports %d or 0, see doc comment)",
-			exitErr.ExitStatus(), wantCode)
-	}
+	require.ErrorAs(t, err, &exitErr, "expected exit status %d, got %v", wantCode, err)
+	assert.Equal(t, wantCode, exitErr.ExitStatus(), "forced command's exit code should reach the guest")
 }
 
 // testProxyLargeTransfer pushes several megabytes through the relay in both

--- a/ftests/proxy_test.go
+++ b/ftests/proxy_test.go
@@ -1,0 +1,539 @@
+package ftests
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/owenthereal/upterm/host/api"
+	"github.com/owenthereal/upterm/ws"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+)
+
+// ProxyTestCases pins the behaviour of the relay's front door at the SSH
+// connection-protocol layer.
+//
+// The relay forwards decrypted SSH *packets* today, so channel numbering,
+// windows, request ordering and close ordering all survive untouched and none
+// of the cases below can fail for a reason the front door is responsible for.
+// Replacing it with a stock golang.org/x/crypto proxy terminates the channel
+// layer on each side and re-originates every channel and every request, at
+// which point each of these becomes a way to lose data silently. They are
+// written against the piper first so that a failure afterwards means the
+// rewrite broke something, rather than meaning the test was never right.
+//
+// Not covered here, deliberately, because upterm's guest surface cannot reach
+// them and a test that cannot fail is worse than no test:
+//
+//   - stderr as a separate stream. Nothing on the host writes to a session
+//     channel's extended-data stream, so a forwarder that dropped Stderr()
+//     entirely would still pass every case in this package.
+//   - stdin half-close. The host ends the session when the guest's stdin
+//     reaches EOF, so there is no post-EOF behaviour to pin.
+//   - a guest whose key the *host* rejects. The relay checks the guest's key
+//     against the session's authorized keys during its own auth, so the host
+//     never sees a key it will refuse. testClientAuthorizedKeyNotMatching
+//     covers the relay-rejects case, which is the one that happens today.
+//
+// All three belong to the forwarder's own unit tests, against a stock SSH
+// server and client with no upterm involved.
+var ProxyTestCases = []FtestCase{
+	testProxyExitStatus,
+	testProxyForcedCommandExitStatus,
+	testProxyLargeTransfer,
+	testProxyWindowChange,
+	testProxyPreShellRequests,
+	testProxyUnknownChannelRequest,
+	testProxyConcurrentGuests,
+	testProxyIdleKeepalive,
+}
+
+// TestProxy runs the channel-proxy characterization tests.
+func (suite *FtestSuite) TestProxy() {
+	suite.runTestCategory(ProxyTestCases)
+}
+
+// shellLineEnding matches what the Host and Client pumps append to input.
+func shellLineEnding() string {
+	if runtime.GOOS == "windows" {
+		return "\r\n"
+	}
+	return "\n"
+}
+
+// exitCodeCommand returns a shell invocation that exits with code.
+func exitCodeCommand(code int) []string {
+	if runtime.GOOS == "windows" {
+		return []string{"powershell", "-NoProfile", "-NoLogo", "-Command", fmt.Sprintf("exit %d", code)}
+	}
+	return []string{"bash", "-c", fmt.Sprintf("exit %d", code)}
+}
+
+// dialGuest opens a raw SSH connection to the relay as a guest, without the
+// pty/shell/pump machinery Client.Join sets up. The request-level cases below
+// need to drive the session channel themselves.
+func dialGuest(t *testing.T, session *api.GetSessionResponse, clientJoinURL string) *ssh.Client {
+	t.Helper()
+
+	auths, err := authMethodsFromFiles([]string{ClientPrivateKey})
+	require.NoError(t, err)
+
+	config := &ssh.ClientConfig{
+		User:            session.SshUser,
+		Auth:            auths,
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}
+
+	u, err := url.Parse(clientJoinURL)
+	require.NoError(t, err)
+
+	var client *ssh.Client
+	if u.Scheme == "ws" || u.Scheme == "wss" {
+		encodedNodeAddr := base64.URLEncoding.EncodeToString([]byte(session.NodeAddr))
+		u.User = url.UserPassword(session.SessionId, encodedNodeAddr)
+		client, err = ws.NewSSHClient(u, config, true)
+	} else {
+		client, err = ssh.Dial("tcp", u.Host, config)
+	}
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+
+	return client
+}
+
+// shareHost starts a host and returns its session record.
+func shareHost(t *testing.T, h *Host, hostShareURL, hostNodeAddr string) *api.GetSessionResponse {
+	t.Helper()
+
+	require.NoError(t, h.Share(hostShareURL))
+	t.Cleanup(h.Close)
+
+	return getAndVerifySession(t, h.AdminSocketFile, hostShareURL, hostNodeAddr)
+}
+
+// testProxyExitStatus pins that an exit status, and the output that precedes
+// it, reach the guest.
+//
+// exit-status is a channel request the host sends immediately before closing
+// the channel (RFC 4254 §6.10). A proxy that closes the downstream channel as
+// soon as its data copy finishes drops it, and the guest reports "no exit
+// status" or -1 with no explanation. This is the most common defect in this
+// class of proxy: moul/sshportal shipped it for years (PR #183).
+//
+// The case used is a session with no pty, which upterm refuses with a message
+// on stdout and exit status 1. That makes the expected status non-zero and
+// deterministic, so the test detects a dropped exit-status, a zeroed payload,
+// and output truncated by an early close, all three.
+func testProxyExitStatus(t *testing.T, hostShareURL, hostNodeAddr, clientJoinURL string) {
+	adminSocketFile := setupAdminSocket(t)
+	session := shareHost(t, &Host{
+		Command:                  getTestShell(),
+		PrivateKeys:              []string{HostPrivateKey},
+		AdminSocketFile:          adminSocketFile,
+		PermittedClientPublicKey: ClientPublicKeyContent,
+	}, hostShareURL, hostNodeAddr)
+
+	client := dialGuest(t, session, clientJoinURL)
+
+	sess, err := client.NewSession()
+	require.NoError(t, err)
+	defer func() { _ = sess.Close() }()
+
+	var stdout bytes.Buffer
+	sess.Stdout = &stdout
+
+	// No RequestPty: upterm rejects the session with exit status 1.
+	require.NoError(t, sess.Shell())
+
+	err = sess.Wait()
+
+	var missing *ssh.ExitMissingError
+	require.NotErrorAs(t, err, &missing,
+		"guest received no exit-status before the channel closed")
+
+	var exitErr *ssh.ExitError
+	require.ErrorAs(t, err, &exitErr, "expected a non-zero exit status, got %v", err)
+	assert.Equal(t, 1, exitErr.ExitStatus(), "exit status payload should survive the relay")
+
+	assert.Contains(t, stdout.String(), "PTY is required",
+		"output written before the exit status should not be truncated by the close")
+}
+
+// testProxyForcedCommandExitStatus pins that a forced command's termination is
+// reported to the guest at all.
+//
+// The exit *code* is deliberately not asserted. upterm's host races the forced
+// command's Wait against the pty's EOF in a run.Group and reports whichever
+// lands first, so the guest sees the command's real code or a clean 0
+// depending on scheduling (host/internal/server.go, HandleSession). That is a
+// host-side defect, unrelated to the relay, and pinning it here would make
+// this test flaky. What the relay owes the guest is that *an* exit status
+// arrives before the channel closes, which is what this asserts.
+func testProxyForcedCommandExitStatus(t *testing.T, hostShareURL, hostNodeAddr, clientJoinURL string) {
+	const wantCode = 42
+
+	adminSocketFile := setupAdminSocket(t)
+	session := shareHost(t, &Host{
+		Command:                  getTestShell(),
+		ForceCommand:             exitCodeCommand(wantCode),
+		PrivateKeys:              []string{HostPrivateKey},
+		AdminSocketFile:          adminSocketFile,
+		PermittedClientPublicKey: ClientPublicKeyContent,
+	}, hostShareURL, hostNodeAddr)
+
+	client := dialGuest(t, session, clientJoinURL)
+
+	sess, err := client.NewSession()
+	require.NoError(t, err)
+	defer func() { _ = sess.Close() }()
+
+	require.NoError(t, sess.RequestPty("xterm", 40, 80, ssh.TerminalModes{}))
+
+	// Hold stdin open. With Session.Stdin nil, x/crypto copies an empty
+	// buffer and calls CloseWrite immediately after Shell, and the host ends
+	// the session on stdin EOF, so the forced command would never get to exit.
+	stdin, err := sess.StdinPipe()
+	require.NoError(t, err)
+	defer func() { _ = stdin.Close() }()
+
+	require.NoError(t, sess.Shell())
+
+	err = sess.Wait()
+
+	var missing *ssh.ExitMissingError
+	require.NotErrorAs(t, err, &missing,
+		"guest received no exit-status before the channel closed")
+
+	var exitErr *ssh.ExitError
+	if errors.As(err, &exitErr) {
+		t.Logf("forced command exit status: %d (host reports %d or 0, see doc comment)",
+			exitErr.ExitStatus(), wantCode)
+	}
+}
+
+// testProxyLargeTransfer pushes several megabytes through the relay in both
+// directions over the sftp subsystem.
+//
+// Packet piping has no per-hop flow control: the guest and the host negotiate
+// one window end to end. A channel-level proxy gives each leg its own 2 MB
+// window and must chain back-pressure between them, so a payload larger than
+// one window is the smallest case that can deadlock or truncate.
+func testProxyLargeTransfer(t *testing.T, hostShareURL, hostNodeAddr, clientJoinURL string) {
+	// Comfortably more than x/crypto's 2 MB per-direction channel window, so
+	// the transfer cannot complete without the window being replenished.
+	const payloadSize = 5 << 20
+
+	testDir := t.TempDir()
+
+	payload := make([]byte, payloadSize)
+	_, err := rand.Read(payload)
+	require.NoError(t, err)
+
+	downloadPath := filepath.Join(testDir, "download.bin")
+	require.NoError(t, os.WriteFile(downloadPath, payload, 0644))
+
+	adminSocketFile := setupAdminSocket(t)
+	session := shareHost(t, &Host{
+		Command:                  getTestShell(),
+		PrivateKeys:              []string{HostPrivateKey},
+		AdminSocketFile:          adminSocketFile,
+		PermittedClientPublicKey: ClientPublicKeyContent,
+	}, hostShareURL, hostNodeAddr)
+
+	c := &Client{PrivateKeys: []string{ClientPrivateKey}}
+	require.NoError(t, c.Join(session, clientJoinURL))
+	defer c.Close()
+
+	sftpClient, err := c.SFTP()
+	require.NoError(t, err)
+	defer func() { _ = sftpClient.Close() }()
+
+	// Host to guest.
+	f, err := sftpClient.Open(downloadPath)
+	require.NoError(t, err)
+	got, err := io.ReadAll(f)
+	_ = f.Close()
+	require.NoError(t, err)
+	require.Equal(t, payloadSize, len(got), "downloaded size should match")
+	assert.True(t, bytes.Equal(payload, got), "downloaded bytes should be identical")
+
+	// Guest to host.
+	uploadPath := filepath.Join(testDir, "upload.bin")
+	w, err := sftpClient.Create(uploadPath)
+	require.NoError(t, err)
+	n, err := io.Copy(w, bytes.NewReader(payload))
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+	require.Equal(t, int64(payloadSize), n, "uploaded size should match")
+
+	uploaded, err := os.ReadFile(uploadPath)
+	require.NoError(t, err)
+	assert.True(t, bytes.Equal(payload, uploaded), "uploaded bytes should be identical")
+}
+
+// testProxyWindowChange resizes the terminal mid-session and checks the host's
+// pty followed.
+//
+// window-change is an unsolicited channel request with WantReply false, sent
+// after the shell has started. A forwarder that only relays the requests it
+// recognises, or that stops reading a channel's request queue once the shell
+// is running, drops it and the guest's terminal silently disagrees with the
+// host's for the rest of the session.
+//
+// The round trip before the resize is load-bearing, and not only because it
+// makes this a mid-session resize. charmbracelet/ssh does not guard sess.pty
+// with the mutex the session struct already embeds, so the "window-change"
+// case writing sess.pty.Window (session.go:391) races any handler reading
+// sess.Pty(), which upterm's HandleSession does on entry. Resizing before the
+// session has exchanged anything makes the two unordered and -race reports it.
+// The bug is upstream and unfixable from here; a guest that resizes its
+// terminal in the first moments of a session can still hit it in production.
+func testProxyWindowChange(t *testing.T, hostShareURL, hostNodeAddr, clientJoinURL string) {
+	if runtime.GOOS == "windows" {
+		t.Skip("stty is not available on Windows")
+	}
+
+	adminSocketFile := setupAdminSocket(t)
+	session := shareHost(t, &Host{
+		Command:                  getTestShell(),
+		PrivateKeys:              []string{HostPrivateKey},
+		AdminSocketFile:          adminSocketFile,
+		PermittedClientPublicKey: ClientPublicKeyContent,
+	}, hostShareURL, hostNodeAddr)
+
+	c := &Client{PrivateKeys: []string{ClientPrivateKey}}
+	require.NoError(t, c.Join(session, clientJoinURL))
+	defer c.Close()
+
+	remoteInputCh, remoteOutputCh := c.InputOutput()
+	remoteScanner := scanner(remoteOutputCh)
+
+	// Establish the session before resizing, so this is a mid-session resize
+	// rather than one racing the shell's start.
+	remoteInputCh <- `echo "before-resize"`
+	expectLine(t, remoteScanner, `echo "before-resize"`, "guest should echo before resizing")
+	expectLine(t, remoteScanner, "before-resize", "guest should see output before resizing")
+
+	// Client.Join requests 40x80. Resize to something unmistakably different;
+	// x/crypto's WindowChange takes rows first, the wire format is columns
+	// first, and getting that backwards is a live hazard in this area.
+	require.NoError(t, c.session.WindowChange(24, 120))
+
+	remoteInputCh <- "stty size"
+	expectLine(t, remoteScanner, "stty size", "guest should echo the command")
+	expectLine(t, remoteScanner, "24 120", "host pty should have been resized to 24 rows by 120 columns")
+}
+
+// testProxyPreShellRequests sends channel requests before starting the shell.
+//
+// env arrives between pty-req and shell, with WantReply true, and RFC 4254 §4
+// requires replies on one channel to come back in the order the requests were
+// sent. A forwarder that answers requests concurrently, or that starts
+// relaying only once it has seen a shell, breaks the guest's handshake in a
+// way that looks like a hang rather than an error.
+func testProxyPreShellRequests(t *testing.T, hostShareURL, hostNodeAddr, clientJoinURL string) {
+	adminSocketFile := setupAdminSocket(t)
+	session := shareHost(t, &Host{
+		Command:                  getTestShell(),
+		PrivateKeys:              []string{HostPrivateKey},
+		AdminSocketFile:          adminSocketFile,
+		PermittedClientPublicKey: ClientPublicKeyContent,
+	}, hostShareURL, hostNodeAddr)
+
+	client := dialGuest(t, session, clientJoinURL)
+
+	sess, err := client.NewSession()
+	require.NoError(t, err)
+	defer func() { _ = sess.Close() }()
+
+	for i := range 4 {
+		require.NoError(t, sess.Setenv(fmt.Sprintf("UPTERM_FTEST_%d", i), fmt.Sprintf("value-%d", i)),
+			"env request %d should be answered", i)
+	}
+
+	require.NoError(t, sess.RequestPty("xterm", 40, 80, ssh.TerminalModes{}))
+
+	stdout, err := sess.StdoutPipe()
+	require.NoError(t, err)
+	stdin, err := sess.StdinPipe()
+	require.NoError(t, err)
+
+	require.NoError(t, sess.Shell(), "shell should start after the pre-shell requests")
+
+	// The session is still usable, which is the point: the requests were
+	// forwarded and answered without desynchronising the channel.
+	_, err = io.WriteString(stdin, "echo pre-shell-ok"+shellLineEnding())
+	require.NoError(t, err)
+
+	outputCh := make(chan string)
+	go func() {
+		buf := make([]byte, 4096)
+		var seen bytes.Buffer
+		for {
+			n, err := stdout.Read(buf)
+			if n > 0 {
+				seen.Write(buf[:n])
+				if bytes.Contains(seen.Bytes(), []byte("pre-shell-ok")) {
+					outputCh <- seen.String()
+					return
+				}
+			}
+			if err != nil {
+				outputCh <- seen.String()
+				return
+			}
+		}
+	}()
+
+	select {
+	case got := <-outputCh:
+		assert.Contains(t, got, "pre-shell-ok", "shell should work after pre-shell requests")
+	case <-time.After(callbackTimeout):
+		t.Fatal("shell produced no output after pre-shell requests")
+	}
+}
+
+// testProxyUnknownChannelRequest sends a channel request nothing understands.
+//
+// RFC 4254 §5.4 says an unrecognised request gets SSH_MSG_CHANNEL_FAILURE, not
+// a dropped connection. The relay must forward it and relay the refusal rather
+// than answering on the host's behalf: the moment it starts deciding which
+// request types are allowed, every extension OpenSSH adds later stops working
+// through upterm, and the failure mode is silence.
+func testProxyUnknownChannelRequest(t *testing.T, hostShareURL, hostNodeAddr, clientJoinURL string) {
+	adminSocketFile := setupAdminSocket(t)
+	session := shareHost(t, &Host{
+		Command:                  getTestShell(),
+		PrivateKeys:              []string{HostPrivateKey},
+		AdminSocketFile:          adminSocketFile,
+		PermittedClientPublicKey: ClientPublicKeyContent,
+	}, hostShareURL, hostNodeAddr)
+
+	client := dialGuest(t, session, clientJoinURL)
+
+	sess, err := client.NewSession()
+	require.NoError(t, err)
+	defer func() { _ = sess.Close() }()
+
+	require.NoError(t, sess.RequestPty("xterm", 40, 80, ssh.TerminalModes{}))
+
+	// Hold stdin open so the host does not end the session out from under the
+	// requests below; see testProxyExitStatus.
+	stdin, err := sess.StdinPipe()
+	require.NoError(t, err)
+	defer func() { _ = stdin.Close() }()
+
+	require.NoError(t, sess.Shell())
+
+	ok, err := sess.SendRequest("not-a-real-request@upterm.dev", true, []byte("payload"))
+	require.NoError(t, err, "an unknown request should be refused, not kill the channel")
+	assert.False(t, ok, "an unknown request should be refused")
+
+	// The connection survived the refusal.
+	ok, err = sess.SendRequest("also-not-real@upterm.dev", true, nil)
+	require.NoError(t, err, "the channel should still be usable after a refused request")
+	assert.False(t, ok)
+
+	_, _, err = client.SendRequest("not-a-real-global@upterm.dev", true, nil)
+	require.NoError(t, err, "the connection should still be usable after a refused global request")
+}
+
+// testProxyConcurrentGuests attaches several guests to one session at once.
+//
+// Every guest is a separate SSH connection through the relay to the same host,
+// and the host fans its pty output out to all of them. A forwarder that keeps
+// per-connection state in the wrong place mixes their channels together; the
+// symptom is one guest seeing another's output, or a single guest leaving and
+// taking the others with it.
+func testProxyConcurrentGuests(t *testing.T, hostShareURL, hostNodeAddr, clientJoinURL string) {
+	const guests = 8
+
+	adminSocketFile := setupAdminSocket(t)
+	h := &Host{
+		Command:                  getTestShell(),
+		PrivateKeys:              []string{HostPrivateKey},
+		AdminSocketFile:          adminSocketFile,
+		PermittedClientPublicKey: ClientPublicKeyContent,
+	}
+	session := shareHost(t, h, hostShareURL, hostNodeAddr)
+
+	hostInputCh, hostOutputCh := h.InputOutput()
+	hostScanner := scanner(hostOutputCh)
+
+	scanners := make([]*bufio.Scanner, 0, guests)
+	for i := range guests {
+		c := &Client{PrivateKeys: []string{ClientPrivateKey}}
+		require.NoError(t, c.Join(session, clientJoinURL), "guest %d should join", i)
+		t.Cleanup(c.Close)
+
+		_, out := c.InputOutput()
+		scanners = append(scanners, scanner(out))
+	}
+
+	// One line from the host must reach every guest.
+	hostInputCh <- `echo "broadcast"`
+	expectLine(t, hostScanner, `echo "broadcast"`, "host should echo the command")
+	expectLine(t, hostScanner, "broadcast", "host should show the output")
+
+	var wg sync.WaitGroup
+	for i, s := range scanners {
+		wg.Add(1)
+		go func(i int, s *bufio.Scanner) {
+			defer wg.Done()
+			expectLine(t, s, "broadcast", "guest %d should see the host's output", i)
+		}(i, s)
+	}
+	wg.Wait()
+}
+
+// testProxyIdleKeepalive leaves a session idle across several keepalive
+// intervals.
+//
+// The host sends keepalive@openssh.com as a channel request with WantReply
+// true every KeepAliveDuration, and its reverse tunnel sends the global-request
+// form to the relay. Any reply, success or failure, satisfies OpenSSH; no reply
+// tears the connection down. This is the case that catches a forwarder which
+// stops servicing a request queue once a channel goes quiet, because in
+// x/crypto an unread request channel blocks the whole connection's mux loop.
+func testProxyIdleKeepalive(t *testing.T, hostShareURL, hostNodeAddr, clientJoinURL string) {
+	adminSocketFile := setupAdminSocket(t)
+	h := &Host{
+		Command:                  getTestShell(),
+		PrivateKeys:              []string{HostPrivateKey},
+		AdminSocketFile:          adminSocketFile,
+		PermittedClientPublicKey: ClientPublicKeyContent,
+	}
+	session := shareHost(t, h, hostShareURL, hostNodeAddr)
+
+	c := &Client{PrivateKeys: []string{ClientPrivateKey}}
+	require.NoError(t, c.Join(session, clientJoinURL))
+	defer c.Close()
+
+	remoteInputCh, remoteOutputCh := c.InputOutput()
+	remoteScanner := scanner(remoteOutputCh)
+
+	remoteInputCh <- `echo "before-idle"`
+	expectLine(t, remoteScanner, `echo "before-idle"`, "guest should echo before going idle")
+	expectLine(t, remoteScanner, "before-idle", "guest should see output before going idle")
+
+	// Long enough for several keepalive rounds in both directions with no
+	// other traffic on the connection.
+	time.Sleep(3 * keepAliveDuration)
+
+	remoteInputCh <- `echo "after-idle"`
+	expectLine(t, remoteScanner, `echo "after-idle"`, "session should survive the idle period")
+	expectLine(t, remoteScanner, "after-idle", "session should still carry output after the idle period")
+}

--- a/ftests/proxy_test.go
+++ b/ftests/proxy_test.go
@@ -289,13 +289,15 @@ func testProxyLargeTransfer(t *testing.T, hostShareURL, hostNodeAddr, clientJoin
 // host's for the rest of the session.
 //
 // The round trip before the resize is load-bearing, and not only because it
-// makes this a mid-session resize. charmbracelet/ssh does not guard sess.pty
-// with the mutex the session struct already embeds, so the "window-change"
-// case writing sess.pty.Window (session.go:391) races any handler reading
+// makes this a mid-session resize. charm.land/ssh does not guard sess.pty with
+// the mutex the session struct already embeds, so the "window-change" case
+// writing sess.pty.Window (session.go:412 in v0.4.3) races any handler reading
 // sess.Pty(), which upterm's HandleSession does on entry. Resizing before the
 // session has exchanged anything makes the two unordered and -race reports it.
-// The bug is upstream and unfixable from here; a guest that resizes its
-// terminal in the first moments of a session can still hit it in production.
+// Unfixable from here, because Pty() is the only way to obtain the window
+// channel; a guest that resizes in the first moments of a session can still
+// hit it in production. Reported upstream with a fix; drop this round trip
+// once a release carrying it is in go.mod.
 func testProxyWindowChange(t *testing.T, hostShareURL, hostNodeAddr, clientJoinURL string) {
 	if runtime.GOOS == "windows" {
 		t.Skip("stty is not available on Windows")

--- a/ftests/proxy_test.go
+++ b/ftests/proxy_test.go
@@ -257,7 +257,7 @@ func testProxyLargeTransfer(t *testing.T, hostShareURL, hostNodeAddr, clientJoin
 	defer func() { _ = sftpClient.Close() }()
 
 	// Host to guest.
-	f, err := sftpClient.Open(downloadPath)
+	f, err := sftpClient.Open(remotePath(downloadPath))
 	require.NoError(t, err)
 	got, err := io.ReadAll(f)
 	_ = f.Close()
@@ -267,7 +267,7 @@ func testProxyLargeTransfer(t *testing.T, hostShareURL, hostNodeAddr, clientJoin
 
 	// Guest to host.
 	uploadPath := filepath.Join(testDir, "upload.bin")
-	w, err := sftpClient.Create(uploadPath)
+	w, err := sftpClient.Create(remotePath(uploadPath))
 	require.NoError(t, err)
 	n, err := io.Copy(w, bytes.NewReader(payload))
 	require.NoError(t, err)

--- a/ftests/sftp_test.go
+++ b/ftests/sftp_test.go
@@ -22,6 +22,7 @@ var SFTPTestCases = []FtestCase{
 	testSFTPDisabled,
 	testSFTPDirectoryListing,
 	testSFTPSetstat,
+	testSFTPNativeWindowsPath,
 }
 
 // TestSFTP runs SFTP tests using the FtestSuite framework
@@ -85,6 +86,63 @@ func TestRemotePath(t *testing.T) {
 
 	assert.Equal(t, "/dir/file.txt", remotePath("/dir/file.txt"))
 	assert.Equal(t, "dir/file.txt", remotePath("dir/file.txt"))
+}
+
+// testSFTPNativeWindowsPath checks that a guest can name a file the way it
+// looks on the host, not only the way the protocol spells it.
+//
+// SFTP paths are POSIX everywhere, so an absolute path on a Windows host
+// travels as /C:/dir/file, which is what remotePath produces and what the
+// other cases here use. But a guest looking at a Windows machine reasonably
+// types C:\dir\file, and that is what the fork this replaced used to accept.
+// The server sees a path the protocol reads as relative, resolves it against
+// the session's start directory, and the request arrives doubled; the host
+// repairs it. Nothing to test off Windows: elsewhere ':' is an ordinary
+// filename character and the path means what it says.
+func testSFTPNativeWindowsPath(t *testing.T, hostShareURL, hostNodeAddr, clientJoinURL string) {
+	if runtime.GOOS != "windows" {
+		t.Skip("native drive-letter paths only arise against a Windows host")
+	}
+
+	require := require.New(t)
+	assert := assert.New(t)
+
+	testDir := t.TempDir()
+	testContent := "Hello from a native Windows path!\n"
+	testFilePath := filepath.Join(testDir, "native-path-test.txt")
+	require.NoError(os.WriteFile(testFilePath, []byte(testContent), 0644))
+
+	adminSocketFile := setupAdminSocket(t)
+
+	h := &Host{
+		Command:                  getTestShell(),
+		PrivateKeys:              []string{HostPrivateKey},
+		AdminSocketFile:          adminSocketFile,
+		PermittedClientPublicKey: ClientPublicKeyContent,
+	}
+	require.NoError(h.Share(hostShareURL))
+	defer h.Close()
+
+	session := getAndVerifySession(t, adminSocketFile, hostShareURL, hostNodeAddr)
+
+	c := &Client{PrivateKeys: []string{ClientPrivateKey}}
+	require.NoError(c.Join(session, clientJoinURL))
+	defer c.Close()
+
+	sftpClient, err := c.SFTP()
+	require.NoError(err, "should be able to open SFTP connection")
+	defer func() { _ = sftpClient.Close() }()
+
+	// Deliberately not remotePath: send the native path, backslashes and all.
+	require.Contains(testFilePath, `\`, "expected a native Windows path from t.TempDir")
+
+	f, err := sftpClient.Open(testFilePath)
+	require.NoError(err, "a native Windows path should be accepted")
+	defer func() { _ = f.Close() }()
+
+	got, err := io.ReadAll(f)
+	require.NoError(err)
+	assert.Equal(testContent, string(got), "downloaded content should match")
 }
 
 // testSFTPDownload tests downloading a file via SFTP

--- a/ftests/sftp_test.go
+++ b/ftests/sftp_test.go
@@ -3,7 +3,10 @@ package ftests
 import (
 	"io"
 	"os"
+	"path"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -24,6 +27,64 @@ var SFTPTestCases = []FtestCase{
 // TestSFTP runs SFTP tests using the FtestSuite framework
 func (suite *FtestSuite) TestSFTP() {
 	suite.runTestCategory(SFTPTestCases)
+}
+
+// remotePath converts a local filesystem path into the POSIX form SFTP uses on
+// the wire.
+//
+// The sftp client sends paths verbatim; there is not one filepath reference in
+// its client.go. On Windows that means an absolute path like C:\dir\file goes
+// out as-is, and the server does not see it as absolute, because POSIX rules
+// need a leading slash. It therefore joins it onto the session's start
+// directory and the request lands on
+// /C:/Users/me/C:/dir/file. OpenSSH's own clients encode Windows absolute
+// paths as /C:/dir/file, which is what this produces. On Unix it is identity.
+//
+// Every path handed to the sftp client has to go through this. Missing one is
+// silent on Unix and only shows up on the Windows job, as a chtimes or open
+// error naming a path with the start directory glued to the front.
+func remotePath(p string) string {
+	s := filepath.ToSlash(p)
+	if filepath.IsAbs(p) && !path.IsAbs(s) {
+		s = "/" + s
+	}
+	return s
+}
+
+// TestRemotePathIsPOSIXAbsolute pins the invariant the SFTP tests depend on.
+//
+// The sftp client sends paths verbatim, and the server treats anything that is
+// not POSIX-absolute as relative to the session's start directory, which upterm
+// sets to the user's home. A native Windows path is not POSIX-absolute, so
+// handing filepath.Join(t.TempDir(), ...) straight to the client made every
+// request land on /C:/Users/me/C:/Users/me/... instead of the file.
+//
+// This fails on Windows if remotePath is ever reduced to the identity, and is
+// the cheap, deterministic counterpart to the functional SFTP tests below,
+// which cover the same ground but only end to end.
+func TestRemotePathIsPOSIXAbsolute(t *testing.T) {
+	local := filepath.Join(t.TempDir(), "file.txt")
+
+	got := remotePath(local)
+	require.True(t, path.IsAbs(got),
+		"remotePath(%q) = %q, which the server would resolve against the start directory", local, got)
+	require.False(t, strings.Contains(got, "\\"),
+		"remotePath(%q) = %q still contains a native separator", local, got)
+}
+
+// TestRemotePath pins the conversion itself, per platform.
+func TestRemotePath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		assert.Equal(t, "/C:/dir/file.txt", remotePath(`C:\dir\file.txt`))
+		assert.Equal(t, "/C:/dir", remotePath(`C:\dir`))
+		// Already in wire form, or relative: left alone.
+		assert.Equal(t, "/C:/dir/file.txt", remotePath("/C:/dir/file.txt"))
+		assert.Equal(t, "dir/file.txt", remotePath(`dir\file.txt`))
+		return
+	}
+
+	assert.Equal(t, "/dir/file.txt", remotePath("/dir/file.txt"))
+	assert.Equal(t, "dir/file.txt", remotePath("dir/file.txt"))
 }
 
 // testSFTPDownload tests downloading a file via SFTP
@@ -72,7 +133,7 @@ func testSFTPDownload(t *testing.T, hostShareURL, hostNodeAddr, clientJoinURL st
 	defer func() { _ = sftpClient.Close() }()
 
 	// Download the file using absolute path (OpenSSH semantics)
-	f, err := sftpClient.Open(testFilePath)
+	f, err := sftpClient.Open(remotePath(testFilePath))
 	require.NoError(err, "should be able to open file via SFTP")
 	defer func() { _ = f.Close() }()
 
@@ -123,7 +184,7 @@ func testSFTPUpload(t *testing.T, hostShareURL, hostNodeAddr, clientJoinURL stri
 	// Upload a new file using absolute path (OpenSSH semantics)
 	uploadFilePath := filepath.Join(testDir, "upload-test.txt")
 	uploadContent := "Hello from SFTP upload test!\n"
-	f, err := sftpClient.Create(uploadFilePath)
+	f, err := sftpClient.Create(remotePath(uploadFilePath))
 	require.NoError(err, "should be able to create file via SFTP")
 
 	_, err = f.Write([]byte(uploadContent))
@@ -182,7 +243,7 @@ func testSFTPReadOnly(t *testing.T, hostShareURL, hostNodeAddr, clientJoinURL st
 	defer func() { _ = sftpClient.Close() }()
 
 	// Download should still work in read-only mode (using absolute path)
-	f, err := sftpClient.Open(testFilePath)
+	f, err := sftpClient.Open(remotePath(testFilePath))
 	require.NoError(err, "download should work in read-only mode")
 	downloadedContent, err := io.ReadAll(f)
 	require.NoError(err)
@@ -191,7 +252,7 @@ func testSFTPReadOnly(t *testing.T, hostShareURL, hostNodeAddr, clientJoinURL st
 
 	// Upload should fail in read-only mode
 	uploadFilePath := filepath.Join(testDir, "upload-should-fail.txt")
-	_, err = sftpClient.Create(uploadFilePath)
+	_, err = sftpClient.Create(remotePath(uploadFilePath))
 	assert.Error(err, "upload should fail in read-only mode")
 }
 
@@ -278,7 +339,7 @@ func testSFTPDirectoryListing(t *testing.T, hostShareURL, hostNodeAddr, clientJo
 	defer func() { _ = sftpClient.Close() }()
 
 	// List test directory using absolute path (OpenSSH semantics)
-	entries, err := sftpClient.ReadDir(testDir)
+	entries, err := sftpClient.ReadDir(remotePath(testDir))
 	require.NoError(err, "should be able to list test directory")
 
 	// Verify we see the expected entries
@@ -293,7 +354,7 @@ func testSFTPDirectoryListing(t *testing.T, hostShareURL, hostNodeAddr, clientJo
 
 	// List subdirectory using absolute path
 	subDirPath := filepath.Join(testDir, "subdir")
-	subEntries, err := sftpClient.ReadDir(subDirPath)
+	subEntries, err := sftpClient.ReadDir(remotePath(subDirPath))
 	require.NoError(err, "should be able to list subdirectory")
 	require.Len(subEntries, 1, "subdir should have one file")
 	assert.Equal("file3.txt", subEntries[0].Name(), "should see file3.txt in subdir")
@@ -343,7 +404,7 @@ func testSFTPSetstat(t *testing.T, hostShareURL, hostNodeAddr, clientJoinURL str
 	defer func() { _ = sftpClient.Close() }()
 
 	// Test 1: Chmod - change file permissions
-	err = sftpClient.Chmod(testFilePath, 0600)
+	err = sftpClient.Chmod(remotePath(testFilePath), 0600)
 	require.NoError(err, "should be able to chmod file")
 
 	info, err := os.Stat(testFilePath)
@@ -353,7 +414,7 @@ func testSFTPSetstat(t *testing.T, hostShareURL, hostNodeAddr, clientJoinURL str
 	assert.NotZero(info.Mode().Perm()&0200, "file should be writable")
 
 	// Test 2: Truncate - change file size
-	err = sftpClient.Truncate(testFilePath, 5)
+	err = sftpClient.Truncate(remotePath(testFilePath), 5)
 	require.NoError(err, "should be able to truncate file")
 
 	info, err = os.Stat(testFilePath)
@@ -366,7 +427,7 @@ func testSFTPSetstat(t *testing.T, hostShareURL, hostNodeAddr, clientJoinURL str
 	assert.Equal("Hello", string(content), "content should be truncated to 'Hello'")
 
 	// Test 3: Truncate to 0 - verify we can truncate to zero bytes
-	err = sftpClient.Truncate(testFilePath, 0)
+	err = sftpClient.Truncate(remotePath(testFilePath), 0)
 	require.NoError(err, "should be able to truncate file to 0 bytes")
 
 	info, err = os.Stat(testFilePath)
@@ -376,7 +437,7 @@ func testSFTPSetstat(t *testing.T, hostShareURL, hostNodeAddr, clientJoinURL str
 	// Test 4: Chtimes - change file timestamps
 	atime := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
 	mtime := time.Date(2021, 6, 15, 12, 30, 0, 0, time.UTC)
-	err = sftpClient.Chtimes(testFilePath, atime, mtime)
+	err = sftpClient.Chtimes(remotePath(testFilePath), atime, mtime)
 	require.NoError(err, "should be able to change file times")
 
 	info, err = os.Stat(testFilePath)

--- a/go.mod
+++ b/go.mod
@@ -44,12 +44,12 @@ require (
 )
 
 require (
+	charm.land/ssh v0.4.3
 	github.com/adrg/xdg v0.5.3
 	github.com/avast/retry-go/v4 v4.7.0
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250319133953-166f707985bc
-	github.com/charmbracelet/ssh v0.0.0-20250826160808-ebfa259c7309
 	github.com/charmbracelet/x/conpty v0.2.0
 	github.com/cli/go-gh/v2 v2.13.0
 	github.com/google/go-github/v48 v48.2.0

--- a/go.mod
+++ b/go.mod
@@ -155,5 +155,3 @@ require (
 )
 
 replace golang.org/x/crypto => github.com/tg123/sshpiper.crypto v0.55.0-sshpiper-20260828
-
-replace github.com/pkg/sftp => github.com/owenthereal/sftp v0.0.0-20260113082633-ef3e1c92482e

--- a/go.sum
+++ b/go.sum
@@ -305,8 +305,6 @@ github.com/olebedev/emitter v0.0.0-20230411050614-349169dec2ba h1:/Q5vvLs180BFH7
 github.com/olebedev/emitter v0.0.0-20230411050614-349169dec2ba/go.mod h1:eT2/Pcsim3XBjbvldGiJBvvgiqZkAFyiOJJsDKXs/ts=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
-github.com/owenthereal/sftp v0.0.0-20260113082633-ef3e1c92482e h1:aTNsPifEBOqyFBeJ66kg55fGiLMM9D6AH0pzzAlqnEY=
-github.com/owenthereal/sftp v0.0.0-20260113082633-ef3e1c92482e/go.mod h1:ZJjziXQfMZHQhZLwCXYsNgAWo7JCwe+ZPgUAuNeb+ck=
 github.com/owenthereal/tmux v0.0.0-20260110065009-80f16deab60d h1:M4eHUCs7KYTLz8jK6sOa+bCXiU2BV8xj9f2QFJsYLeA=
 github.com/owenthereal/tmux v0.0.0-20260110065009-80f16deab60d/go.mod h1:LmUG3DzUnCf1F03dVT+dyJADTiFN+dK+ZQHCqfkmvrQ=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
@@ -324,6 +322,8 @@ github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/sftp v1.13.10 h1:+5FbKNTe5Z9aspU88DPIKJ9z2KZoaGCu6Sr6kKR/5mU=
+github.com/pkg/sftp v1.13.10/go.mod h1:bJ1a7uDhrX/4OII+agvy28lzRvQrmIQuaHrcI1HbeGA=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+charm.land/ssh v0.4.3 h1:hr5cYmlUYsP+KxyG/ug7ZMzKKN9f6VOD9yPpcGqdzzM=
+charm.land/ssh v0.4.3/go.mod h1:so/3IECPNlYZSnE7JKn7NFmcUyyxJqIAeM4TJy35qPk=
 git.sr.ht/~jackmordaunt/go-toast v1.1.2 h1:/yrfI55LRt1M7H1vkaw+NaH1+L1CDxrqDltwm5euVuE=
 git.sr.ht/~jackmordaunt/go-toast v1.1.2/go.mod h1:jA4OqHKTQ4AFBdwrSnwnskUIIS3HYzlJSgdzCKqfavo=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
@@ -56,8 +58,6 @@ github.com/charmbracelet/colorprofile v0.4.1 h1:a1lO03qTrSIRaK8c3JRxJDZOvhvIeSco
 github.com/charmbracelet/colorprofile v0.4.1/go.mod h1:U1d9Dljmdf9DLegaJ0nGZNJvoXAhayhmidOdcBwAvKk=
 github.com/charmbracelet/lipgloss v1.1.1-0.20250319133953-166f707985bc h1:nFRtCfZu/zkltd2lsLUPlVNv3ej/Atod9hcdbRZtlys=
 github.com/charmbracelet/lipgloss v1.1.1-0.20250319133953-166f707985bc/go.mod h1:aKC/t2arECF6rNOnaKaVU6y4t4ZeHQzqfxedE/VkVhA=
-github.com/charmbracelet/ssh v0.0.0-20250826160808-ebfa259c7309 h1:dCVbCRRtg9+tsfiTXTp0WupDlHruAXyp+YoxGVofHHc=
-github.com/charmbracelet/ssh v0.0.0-20250826160808-ebfa259c7309/go.mod h1:R9cISUs5kAH4Cq/rguNbSwcR+slE5Dfm8FEs//uoIGE=
 github.com/charmbracelet/x/ansi v0.11.6 h1:GhV21SiDz/45W9AnV2R61xZMRri5NlLnl6CVF7ihZW8=
 github.com/charmbracelet/x/ansi v0.11.6/go.mod h1:2JNYLgQUsyqaiLovhU2Rv/pb8r6ydXKS3NIttu3VGZQ=
 github.com/charmbracelet/x/cellbuf v0.0.15 h1:ur3pZy0o6z/R7EylET877CBxaiE1Sp1GMxoFPAIztPI=

--- a/host/internal/pty.go
+++ b/host/internal/pty.go
@@ -1,6 +1,11 @@
 package internal
 
-import "io"
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+)
 
 // PTY represents a pseudo-terminal abstraction that works across platforms.
 // On Unix, it wraps a traditional PTY created via creack/pty.
@@ -31,4 +36,44 @@ type PTY interface {
 	// On Unix, this delegates to exec.Cmd.Process.Kill().
 	// On Windows, this calls TerminateProcess on the handle.
 	Kill() error
+}
+
+// ExitError reports that a PTY's process exited with a non-zero status.
+//
+// Unix gets this for free from exec.Cmd.Wait, which returns *exec.ExitError.
+// Windows waits on a process handle rather than an exec.Cmd, so it has no
+// such error to return and needs this to carry the code instead of burying it
+// in a message string.
+type ExitError struct {
+	Code int
+}
+
+func (e *ExitError) Error() string {
+	return fmt.Sprintf("exit status %d", e.Code)
+}
+
+// exitCode reports the status a PTY's process exited with, given the error
+// from Wait. The second return is false when the process did not exit under
+// its own control: exec reports -1 for a process stopped by a signal, which is
+// what happens when the session is torn down and the pty is closed underneath
+// a still-running command. A caller reporting an exit status to an SSH client
+// must not pass that on, because the status is marshalled as a uint32.
+func exitCode(err error) (int, bool) {
+	if err == nil {
+		return 0, true
+	}
+
+	var (
+		execErr *exec.ExitError
+		ptyErr  *ExitError
+	)
+	switch {
+	case errors.As(err, &execErr):
+		code := execErr.ExitCode()
+		return code, code >= 0
+	case errors.As(err, &ptyErr):
+		return ptyErr.Code, ptyErr.Code >= 0
+	}
+
+	return 0, false
 }

--- a/host/internal/pty.go
+++ b/host/internal/pty.go
@@ -45,7 +45,13 @@ type PTY interface {
 // such error to return and needs this to carry the code instead of burying it
 // in a message string.
 type ExitError struct {
-	Code int
+	// Code is the status GetExitCodeProcess reported, kept unsigned because
+	// that is what Windows produces and what SSH puts on the wire. On a
+	// 32-bit build, narrowing it to int would make every status with the high
+	// bit set negative -- an unhandled exception such as 0xC0000005, or a
+	// deliberate "exit -1" -- and exitCode would then read it as a process
+	// that never exited under its own control.
+	Code uint32
 }
 
 func (e *ExitError) Error() string {
@@ -58,6 +64,11 @@ func (e *ExitError) Error() string {
 // what happens when the session is torn down and the pty is closed underneath
 // a still-running command. A caller reporting an exit status to an SSH client
 // must not pass that on, because the status is marshalled as a uint32.
+//
+// That -1 check belongs to exec alone. Windows has no signals to report here,
+// so every ExitError carries a real status, and the int it is returned as is
+// only a courier: ssh.Session.Exit converts back to uint32, so a status that
+// does not fit a 32-bit int arrives intact anyway.
 func exitCode(err error) (int, bool) {
 	if err == nil {
 		return 0, true
@@ -72,7 +83,7 @@ func exitCode(err error) (int, bool) {
 		code := execErr.ExitCode()
 		return code, code >= 0
 	case errors.As(err, &ptyErr):
-		return ptyErr.Code, ptyErr.Code >= 0
+		return int(ptyErr.Code), true
 	}
 
 	return 0, false

--- a/host/internal/pty_test.go
+++ b/host/internal/pty_test.go
@@ -1,0 +1,67 @@
+package internal
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// exitCode decides what status the guest is told the command exited with, so
+// getting it wrong is invisible locally and wrong on the wire.
+func TestExitCode(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		wantCode   int
+		wantExited bool
+	}{
+		{
+			name:       "no error is a clean exit",
+			err:        nil,
+			wantCode:   0,
+			wantExited: true,
+		},
+		{
+			name:       "windows exit status",
+			err:        &ExitError{Code: 3},
+			wantCode:   3,
+			wantExited: true,
+		},
+		{
+			name:       "wrapped windows exit status",
+			err:        errors.Join(errors.New("run group"), &ExitError{Code: 3}),
+			wantCode:   3,
+			wantExited: true,
+		},
+		{
+			name:       "an error that is not an exit tells us nothing",
+			err:        errors.New("GetExitCodeProcess failed"),
+			wantCode:   0,
+			wantExited: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			code, exited := exitCode(tt.err)
+			assert.Equal(t, tt.wantExited, exited)
+			assert.Equal(t, tt.wantCode, code)
+		})
+	}
+}
+
+// A Windows status with the high bit set is still a status.
+//
+// Unhandled exceptions look like 0xC0000005, and "exit -1" becomes 0xFFFFFFFF.
+// On a 32-bit build these do not fit a positive int, so carrying them as one
+// used to make exitCode report "did not exit" and the guest got a flat 1. The
+// int is only a courier -- ssh.Session.Exit converts back to uint32 -- so the
+// invariant that matters is what comes out the other side of that conversion.
+func TestExitCodeKeepsHighWindowsStatuses(t *testing.T) {
+	for _, status := range []uint32{0xC0000005, 0xFFFFFFFF, 0x80000003} {
+		code, exited := exitCode(&ExitError{Code: status})
+		assert.True(t, exited, "status %#x is an exit, not a signal", status)
+		assert.Equal(t, status, uint32(code), "status %#x should survive the trip to the wire", status)
+	}
+}

--- a/host/internal/pty_unix_test.go
+++ b/host/internal/pty_unix_test.go
@@ -1,0 +1,40 @@
+//go:build !windows
+
+package internal
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A process stopped by a signal has no status to report.
+//
+// exec returns -1 for it, and that is what happens when a session is torn down
+// and the pty closes underneath a command that is still running. SSH marshals
+// exit-status as a uint32, so passing -1 through would tell the guest the
+// command exited 4294967295.
+func TestExitCodeSignalledProcess(t *testing.T) {
+	cmd := exec.Command("sleep", "30")
+	require.NoError(t, cmd.Start())
+	require.NoError(t, cmd.Process.Kill())
+
+	err := cmd.Wait()
+	require.Error(t, err)
+
+	code, exited := exitCode(err)
+	assert.False(t, exited, "a signalled process did not exit under its own control")
+	assert.Negative(t, code)
+}
+
+// An ordinary non-zero exit is reported as itself.
+func TestExitCodeExecExitStatus(t *testing.T) {
+	err := exec.Command("sh", "-c", "exit 7").Run()
+	require.Error(t, err)
+
+	code, exited := exitCode(err)
+	assert.True(t, exited)
+	assert.Equal(t, 7, code)
+}

--- a/host/internal/pty_windows.go
+++ b/host/internal/pty_windows.go
@@ -200,7 +200,7 @@ func (p *pty) Wait() error {
 	// This ensures proper shutdown order
 
 	if exitCode != 0 {
-		return &ExitError{Code: int(exitCode)}
+		return &ExitError{Code: exitCode}
 	}
 
 	return nil

--- a/host/internal/pty_windows.go
+++ b/host/internal/pty_windows.go
@@ -200,7 +200,7 @@ func (p *pty) Wait() error {
 	// This ensures proper shutdown order
 
 	if exitCode != 0 {
-		return fmt.Errorf("exit status %d", exitCode)
+		return &ExitError{Code: int(exitCode)}
 	}
 
 	return nil

--- a/host/internal/server.go
+++ b/host/internal/server.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"time"
 
-	gssh "github.com/charmbracelet/ssh"
+	gssh "charm.land/ssh"
 	"github.com/owenthereal/upterm/host/api"
 	"github.com/owenthereal/upterm/host/sftp"
 	"github.com/owenthereal/upterm/server"

--- a/host/internal/server.go
+++ b/host/internal/server.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 	"net"
 	"os"
-	"os/exec"
 	"time"
 
 	gssh "github.com/charmbracelet/ssh"
@@ -214,12 +213,32 @@ func (h *sessionHandler) HandleSession(sess gssh.Session) {
 	if !isPty {
 		_, _ = io.WriteString(sess, "PTY is required.\n")
 		_ = sess.Exit(1)
+		// Exit closes the channel. Without returning, the rest of the handler
+		// ran against a dead session: it attached it to the shared output
+		// writer, started a keepalive ticker and a window-change loop, and
+		// finished with a second Exit that could only fail.
+		return
 	}
 
 	var (
 		g    run.Group
 		err  error
 		ptmx = h.ptmx
+	)
+
+	// The forced command's exit status, recorded by the actor that waits on it
+	// rather than read back off run.Group's return value.
+	//
+	// run.Group.Run returns whichever actor finished first, and when a forced
+	// command exits, two of them unblock at the same instant: the wait, which
+	// carries the status, and the output copy, which sees the pty's EOF and
+	// returns nil. Reading the status off Run therefore made the guest's exit
+	// code a coin toss; measured, `--force-command 'exit 42'` reported 42 or 0
+	// depending on scheduling. Run drains every actor before returning, so
+	// reading these afterwards is ordered.
+	var (
+		cmdCode   int
+		cmdExited bool
 	)
 
 	// simulate openssh keepalive
@@ -267,7 +286,9 @@ func (h *sessionHandler) HandleSession(sess gssh.Session) {
 		}
 		{
 			g.Add(func() error {
-				return ptmx.Wait()
+				err := ptmx.Wait()
+				cmdCode, cmdExited = exitCode(err)
+				return err
 			}, func(err error) {
 				cancel()
 				_ = ptmx.Close()
@@ -333,13 +354,16 @@ func (h *sessionHandler) HandleSession(sess gssh.Session) {
 		})
 	}
 
-	if err := g.Run(); err != nil {
-		if exitError, ok := err.(*exec.ExitError); ok {
-			_ = sess.Exit(exitError.ExitCode())
-		} else {
-			_ = sess.Exit(1)
-		}
-	} else {
+	runErr := g.Run()
+
+	switch {
+	case cmdExited:
+		// A forced command ran and terminated under its own control. Its
+		// status is the session's, whichever actor unblocked run.Group first.
+		_ = sess.Exit(cmdCode)
+	case runErr != nil:
+		_ = sess.Exit(1)
+	default:
 		_ = sess.Exit(0)
 	}
 }

--- a/host/internal/sftp.go
+++ b/host/internal/sftp.go
@@ -7,7 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"strings"
+	"runtime"
 	"time"
 
 	gssh "charm.land/ssh"
@@ -99,25 +99,21 @@ func (s *SFTPSession) checkPermission(op hostsftp.Operation, paths ...string) er
 	return nil
 }
 
-// resolvePath resolves a path following standard OpenSSH/SCP semantics.
-// - Tilde paths (~ or ~/path) are expanded to home directory
-// - Absolute paths (starting with /) are used as-is
-// - Relative paths are resolved from the user's home directory
+// resolvePath turns the POSIX path the client sent into a local one.
 //
-// Note: WithStartDirectory(home) is set on the SFTP server, which handles
-// relative path resolution at the protocol level.
+// Absolute paths are used as-is. Relative paths arrive already resolved
+// against the session's start directory, which WithStartDirectory sets to the
+// user's home, so there is nothing to do for them here.
+//
+// There is no tilde handling. Tilde expansion is not part of SFTP, and the
+// branch that used to be here could never run: the library resolves every
+// request against the start directory before a handler sees it, so reqPath is
+// always absolute by this point and never still begins with "~". Relative
+// paths already resolve to the home directory, so "notes.txt" covers what
+// "~/notes.txt" was reaching for.
 func (s *SFTPSession) resolvePath(reqPath string) (string, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
-	}
-
-	// Handle tilde expansion (OpenSSH may send literal ~ or ~/path)
-	if reqPath == "~" {
-		return home, nil
-	}
-	if strings.HasPrefix(reqPath, "~/") {
-		return filepath.Join(home, reqPath[2:]), nil
+	if runtime.GOOS == "windows" {
+		reqPath = undoubleDriveLetter(reqPath)
 	}
 
 	// SFTP sends Windows paths like "/C:/foo" - strip leading "/" for proper handling
@@ -126,6 +122,38 @@ func (s *SFTPSession) resolvePath(reqPath string) (string, error) {
 	}
 
 	return filepath.Clean(reqPath), nil
+}
+
+// undoubleDriveLetter repairs a path a client sent in native Windows form.
+//
+// SFTP paths are POSIX on every platform, so an absolute path on a Windows
+// host travels as /C:/dir/file. A client that sends the native C:\dir\file or
+// C:/dir/file is sending something the protocol reads as relative, so the
+// server resolves it against the session's start directory and the request
+// arrives doubled, as /C:/Users/me/C:/dir/file.
+//
+// Windows filenames cannot contain ':', so a drive letter anywhere but the
+// front can only have arrived this way, and the last one is the path the
+// client meant. Callers must only apply this on Windows: ':' is legal in a
+// POSIX filename, and on a Linux host a client asking for C:\foo really is
+// naming a file under the start directory.
+func undoubleDriveLetter(p string) string {
+	last := -1
+	for i := 0; i+2 < len(p); i++ {
+		if p[i] == '/' && p[i+2] == ':' && isDriveLetter(p[i+1]) {
+			last = i
+		}
+	}
+
+	// last == 0 is the ordinary "/C:/dir" form, which needs no repair.
+	if last > 0 {
+		return p[last:]
+	}
+	return p
+}
+
+func isDriveLetter(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
 }
 
 // sftpFileReader handles file download requests

--- a/host/internal/sftp.go
+++ b/host/internal/sftp.go
@@ -132,15 +132,24 @@ func (s *SFTPSession) resolvePath(reqPath string) (string, error) {
 // server resolves it against the session's start directory and the request
 // arrives doubled, as /C:/Users/me/C:/dir/file.
 //
-// Windows filenames cannot contain ':', so a drive letter anywhere but the
-// front can only have arrived this way, and the last one is the path the
-// client meant. Callers must only apply this on Windows: ':' is legal in a
-// POSIX filename, and on a Linux host a client asking for C:\foo really is
-// naming a file under the start directory.
+// A path component of exactly "X:" cannot be a filename -- Windows does not
+// allow ':' in one -- so a drive letter anywhere but the front can only have
+// arrived this way, and the last one is the path the client meant. Callers
+// must only apply this on Windows: ':' is legal in a POSIX filename, and on a
+// Linux host a client asking for C:\foo really is naming a file under the
+// start directory.
 func undoubleDriveLetter(p string) string {
 	last := -1
 	for i := 0; i+2 < len(p); i++ {
-		if p[i] == '/' && p[i+2] == ':' && isDriveLetter(p[i+1]) {
+		if p[i] != '/' || p[i+2] != ':' || !isDriveLetter(p[i+1]) {
+			continue
+		}
+		// The drive must be the whole component: it either introduces a
+		// path or ends the string. A colon that merely follows a one-letter
+		// name is NTFS alternate-data-stream syntax -- "/C:/dir/f:meta" is
+		// the "meta" stream of the file "f" -- and rewriting that would
+		// silently retarget the request at drive F: instead.
+		if i+3 == len(p) || p[i+3] == '/' {
 			last = i
 		}
 	}

--- a/host/internal/sftp.go
+++ b/host/internal/sftp.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	gssh "github.com/charmbracelet/ssh"
+	gssh "charm.land/ssh"
 	hostsftp "github.com/owenthereal/upterm/host/sftp"
 	"github.com/owenthereal/upterm/utils"
 	"github.com/pkg/sftp"

--- a/host/internal/sftp_test.go
+++ b/host/internal/sftp_test.go
@@ -164,6 +164,25 @@ func TestUndoubleDriveLetter(t *testing.T) {
 			want: "/C:/Users/me/ab:/notes.txt",
 		},
 		{
+			// "f:metadata" is the NTFS alternate data stream "metadata" on
+			// the file "f". Reading the "/f:" as a drive would send the
+			// request to drive F: instead of the file the client named.
+			name: "alternate data stream on a one-letter file is not a drive",
+			in:   "/C:/Users/me/f:metadata",
+			want: "/C:/Users/me/f:metadata",
+		},
+		{
+			name: "alternate data stream is not a drive even when doubled",
+			in:   "/C:/Users/me/C:/Users/me/f:metadata",
+			want: "/C:/Users/me/f:metadata",
+		},
+		{
+			// A drive can end the path: this is what "ls C:" doubles into.
+			name: "trailing bare drive is repaired",
+			in:   "/C:/Users/me/D:",
+			want: "/D:",
+		},
+		{
 			name: "empty",
 			in:   "",
 			want: "",

--- a/host/internal/sftp_test.go
+++ b/host/internal/sftp_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,17 +12,20 @@ import (
 )
 
 func TestSFTPSession_resolvePath(t *testing.T) {
-	home, err := os.UserHomeDir()
-	require.NoError(t, err)
-
 	session := &SFTPSession{
 		readOnly: false,
 	}
 
 	// Test cases for path resolution:
-	// - Tilde paths (~ or ~/path) are expanded to home directory
 	// - Absolute paths (starting with /) are used as-is
 	// - Relative paths are passed through (WithStartDirectory handles them at protocol level)
+	//
+	// There are deliberately no tilde cases. Tilde expansion is not part of
+	// SFTP, and the branch that used to handle it could never run in
+	// production: the library resolves every request against the start
+	// directory first, so a handler never sees a path still starting with "~".
+	// Testing resolvePath directly bypassed that and made the dead code look
+	// alive.
 	tests := []struct {
 		name     string
 		reqPath  string
@@ -47,27 +51,6 @@ func TestSFTPSession_resolvePath(t *testing.T) {
 			name:     "absolute path with double dots",
 			reqPath:  "/tmp/../etc/passwd",
 			wantPath: "/etc/passwd",
-		},
-		// Tilde expansion (OpenSSH may send literal ~)
-		{
-			name:     "tilde only expands to home",
-			reqPath:  "~",
-			wantPath: home,
-		},
-		{
-			name:     "tilde with path expands to home subdir",
-			reqPath:  "~/Documents",
-			wantPath: filepath.Join(home, "Documents"),
-		},
-		{
-			name:     "tilde with nested path",
-			reqPath:  "~/Documents/projects/file.txt",
-			wantPath: filepath.Join(home, "Documents/projects/file.txt"),
-		},
-		{
-			name:     "tilde with trailing slash",
-			reqPath:  "~/upterm/",
-			wantPath: filepath.Join(home, "upterm"),
 		},
 		// Relative paths - passed through as-is (library handles with WithStartDirectory)
 		{
@@ -130,6 +113,106 @@ func TestSFTPSession_resolvePath(t *testing.T) {
 			// Use filepath.FromSlash to convert expected path to native separators
 			// since filepath.Clean in resolvePath produces native paths
 			assert.Equal(t, filepath.FromSlash(tt.wantPath), gotPath)
+		})
+	}
+}
+
+// TestUndoubleDriveLetter covers the repair itself, which is pure so that it is
+// exercised on every platform rather than only on the Windows job.
+func TestUndoubleDriveLetter(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			// What a client sending the native "C:\\Users\\me\\notes.txt" or
+			// "C:/Users/me/notes.txt" produces once the server has resolved it
+			// against a start directory of /C:/Users/me.
+			name: "doubled drive letter is repaired",
+			in:   "/C:/Users/me/C:/Users/me/notes.txt",
+			want: "/C:/Users/me/notes.txt",
+		},
+		{
+			name: "doubled across different drives",
+			in:   "/C:/Users/me/D:/data/notes.txt",
+			want: "/D:/data/notes.txt",
+		},
+		{
+			name: "lowercase drive letter",
+			in:   "/c:/users/me/c:/users/me/notes.txt",
+			want: "/c:/users/me/notes.txt",
+		},
+		{
+			name: "already canonical is left alone",
+			in:   "/C:/Users/me/notes.txt",
+			want: "/C:/Users/me/notes.txt",
+		},
+		{
+			name: "bare drive is left alone",
+			in:   "/C:",
+			want: "/C:",
+		},
+		{
+			name: "posix path without a drive letter is left alone",
+			in:   "/home/me/notes.txt",
+			want: "/home/me/notes.txt",
+		},
+		{
+			name: "colon not preceded by a single letter is not a drive",
+			in:   "/C:/Users/me/ab:/notes.txt",
+			want: "/C:/Users/me/ab:/notes.txt",
+		},
+		{
+			name: "empty",
+			in:   "",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, undoubleDriveLetter(tt.in))
+		})
+	}
+}
+
+// TestSFTPSession_resolvePathWindows covers what a guest can type as the remote
+// path against a Windows host. The protocol form is /C:/dir/file, but people
+// reasonably type the path they see in Explorer, and the fork this replaced
+// accepted those, so refusing them now would be a silent regression.
+func TestSFTPSession_resolvePathWindows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("drive-letter paths only resolve on Windows")
+	}
+
+	session := &SFTPSession{}
+	const want = `C:\Users\me\notes.txt`
+
+	// These are the requests as a handler sees them, after the library has
+	// resolved them against a start directory of /C:/Users/me. Only two shapes
+	// reach here: `notes.txt` and `/C:/Users/me/notes.txt` both arrive already
+	// canonical, and both native spellings arrive doubled, because the library
+	// converts separators before it joins.
+	tests := []struct {
+		name    string
+		reqPath string
+	}{
+		{
+			name:    "canonical, or a relative path resolved against the start directory",
+			reqPath: "/C:/Users/me/notes.txt",
+		},
+		{
+			name:    `native C:\Users\me\notes.txt or C:/Users/me/notes.txt`,
+			reqPath: "/C:/Users/me/C:/Users/me/notes.txt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := session.resolvePath(tt.reqPath)
+			require.NoError(t, err)
+			assert.Equal(t, want, got)
 		})
 	}
 }

--- a/io/reader.go
+++ b/io/reader.go
@@ -22,26 +22,40 @@ type readResult struct {
 	err error
 }
 
-func (r contextReader) Read(p []byte) (n int, err error) {
+// Read reads from the underlying reader, abandoning the read if the context is
+// cancelled first.
+//
+// The read runs in a goroutine because the underlying reader has no way to be
+// interrupted. That goroutine outlives an abandoned Read, so it must not touch
+// anything the caller owns: it reads into its own buffer, and the bytes are
+// copied into p only if the result arrives in time. It used to read straight
+// into p, which meant a read that completed after its Read call had already
+// returned wrote into a buffer io.Copy had moved on and reused.
+//
+// The channel is buffered so the abandoned goroutine can finish and exit rather
+// than blocking forever on a send nobody is waiting for. It previously also
+// closed the channel on the way out, so a Read racing a cancelled context could
+// receive the zero value and report (0, nil) -- which io.Copy treats as neither
+// data nor EOF, and spins on.
+func (r contextReader) Read(p []byte) (int, error) {
+	// Never start a read the caller has already given up on.
+	select {
+	case <-r.ctx.Done():
+		return 0, r.ctx.Err()
+	default:
+	}
+
 	c := make(chan readResult, 1)
+	buf := make([]byte, len(p))
 
-	go func(ctx context.Context, reader io.Reader) {
-		// close by the sender
-		defer close(c)
-
-		// return early if context is done
-		select {
-		case <-ctx.Done():
-			return
-		default:
-		}
-
-		n, err := reader.Read(p)
+	go func(reader io.Reader) {
+		n, err := reader.Read(buf)
 		c <- readResult{n, err}
-	}(r.ctx, r.Reader)
+	}(r.Reader)
 
 	select {
 	case rr := <-c:
+		copy(p, buf[:rr.n])
 		return rr.n, rr.err
 	case <-r.ctx.Done():
 		return 0, r.ctx.Err()

--- a/io/reader_test.go
+++ b/io/reader_test.go
@@ -47,10 +47,13 @@ func Test_ContextReader(t *testing.T) {
 	t.Run("cancel context during copy", func(t *testing.T) {
 		t.Parallel()
 
+		// The read cannot be interrupted, so it does complete, late and
+		// unheard. It must not reach t: this used to call t.Error on the way
+		// out, which fires after the subtest has finished and panics the whole
+		// binary with "Fail in goroutine after ... has completed".
 		r := readFunc(func(p []byte) (int, error) {
 			time.Sleep(5 * time.Second) // simulate slow read
-			t.Error("should never get here")
-			return 0, nil
+			return copy(p, "late"), nil
 		})
 		w := bytes.NewBuffer(nil)
 
@@ -64,6 +67,9 @@ func Test_ContextReader(t *testing.T) {
 		got := err
 		if diff := cmp.Diff(want.Error(), got.Error()); diff != "" {
 			t.Errorf("want=%s got=%s:\n%s", want, got, diff)
+		}
+		if w.Len() != 0 {
+			t.Errorf("abandoned read delivered %q", w.String())
 		}
 	})
 

--- a/io/writer.go
+++ b/io/writer.go
@@ -1,7 +1,10 @@
 package io
 
 import (
+	"errors"
+	"fmt"
 	"io"
+	"reflect"
 	"sync"
 )
 
@@ -51,14 +54,34 @@ func NewMultiWriter(bufferSize int, writers ...io.Writer) *MultiWriter {
 
 // MultiWriter is a concurrent safe writer that allows appending/removing writers.
 // Newly appended writers get the last write to preserve last output.
+//
+// Attached writers are tracked by identity, so they must be comparable; see
+// checkRemovable, which is how Append enforces it. NewMultiWriter does not,
+// because it cannot report the error, so prefer Append.
 type MultiWriter struct {
+	// writeMu serializes the fan-out. Two producers must not write to the
+	// same attached writer at once: many writers are not concurrency safe,
+	// and even those that are would interleave halves of two writes.
 	writeMu sync.Mutex
-	writers []io.Writer
+
+	// membersMu guards writers. It is deliberately not writeMu: it is never
+	// held while writing to an attached writer, so Append and Remove never
+	// wait on one. See Write for why that matters.
+	membersMu sync.Mutex
+	writers   []io.Writer
 
 	buffer *buffer
 }
 
 func (t *MultiWriter) Append(writers ...io.Writer) error {
+	// Reject anything Remove could not later take back out, before it is
+	// attached and before it is written to.
+	for _, w := range writers {
+		if err := checkRemovable(w); err != nil {
+			return err
+		}
+	}
+
 	// write last buffer to new writers
 	if t.buffer.Size() > 0 {
 		for _, w := range writers {
@@ -71,16 +94,35 @@ func (t *MultiWriter) Append(writers ...io.Writer) error {
 		}
 	}
 
-	t.writeMu.Lock()
-	defer t.writeMu.Unlock()
+	t.membersMu.Lock()
+	defer t.membersMu.Unlock()
 	t.writers = append(t.writers, writers...)
 
 	return nil
 }
 
+// checkRemovable rejects a writer that Remove could not match.
+//
+// Writers are tracked by identity, so Remove compares interface values, and
+// comparing two interface values that hold the same non-comparable dynamic
+// type -- a slice, map, or func with a value receiver -- panics at run time.
+// Write removes the writers that failed it, so that panic would land in the
+// host's pty copy and take the whole process down. Refusing the writer at the
+// door reports the mistake to the caller that made it, at the one point where
+// it is still fixable.
+func checkRemovable(w io.Writer) error {
+	if w == nil {
+		return errors.New("multiwriter: writer is nil")
+	}
+	if rt := reflect.TypeOf(w); !rt.Comparable() {
+		return fmt.Errorf("multiwriter: writer of type %s is not comparable, so it could never be removed", rt)
+	}
+	return nil
+}
+
 func (t *MultiWriter) Remove(writers ...io.Writer) {
-	t.writeMu.Lock()
-	defer t.writeMu.Unlock()
+	t.membersMu.Lock()
+	defer t.membersMu.Unlock()
 
 	// Counts down to zero: the loop used to stop at 1, so whichever writer sat
 	// at index 0 could never be removed.
@@ -98,14 +140,15 @@ func (t *MultiWriter) Remove(writers ...io.Writer) {
 //
 // Two things here are deliberate, and both were bugs.
 //
-// The writers are snapshotted under the lock and written to with the lock
-// released. Holding it across the writes made Append and Remove wait on
-// whatever the slowest attached writer was doing, and a guest that stops
-// reading its SSH channel blocks in Write indefinitely once the channel window
-// fills. That wedged the host: HandleSession removes its writer on the way out,
-// so Remove blocked, HandleSession never returned, and the client-left event it
-// emits on the way out was never sent. It also meant one stuck guest stopped
-// output reaching every other guest and the host's own terminal.
+// The membership lock is released before any writer is written to. Holding one
+// lock for both jobs made Append and Remove wait on whatever the slowest
+// attached writer was doing, and a guest that stops reading its SSH channel
+// blocks in Write indefinitely once the channel window fills. That wedged the
+// host: HandleSession removes its writer on the way out, so Remove blocked,
+// HandleSession never returned, and the client-left event it emits on the way
+// out was never sent. Writes are still serialized among themselves, by
+// writeMu, because concurrent producers must not interleave in a writer or
+// race one that is not concurrency safe.
 //
 // A failing writer is dropped rather than reported. This is a broadcast to
 // whoever is attached, and the producer is the host's pty: returning an error
@@ -122,12 +165,15 @@ func (t *MultiWriter) Remove(writers ...io.Writer) {
 // per-writer buffering, so that a guest which cannot keep up is dropped rather
 // than allowed to slow the session down. Tracked in owenthereal/upterm#524.
 func (t *MultiWriter) Write(p []byte) (int, error) {
+	t.writeMu.Lock()
+	defer t.writeMu.Unlock()
+
 	t.buffer.Append(p)
 
-	t.writeMu.Lock()
+	t.membersMu.Lock()
 	writers := make([]io.Writer, len(t.writers))
 	copy(writers, t.writers)
-	t.writeMu.Unlock()
+	t.membersMu.Unlock()
 
 	var failed []io.Writer
 	for _, w := range writers {

--- a/io/writer.go
+++ b/io/writer.go
@@ -110,12 +110,21 @@ func (t *MultiWriter) Append(writers ...io.Writer) error {
 // host's pty copy and take the whole process down. Refusing the writer at the
 // door reports the mistake to the caller that made it, at the one point where
 // it is still fixable.
+//
+// The question has to be asked of the value, not the type. A struct wrapping
+// an io.Writer is a comparable type, because an interface field is one, yet
+// comparing two of them still panics if the writers inside are funcs.
+// reflect.Value.Comparable walks into the interface and answers for what is
+// actually there, and promises the comparison will not panic when it says yes.
+//
+// This is checked once per attached writer, on a path that runs when a guest
+// joins, so the reflection costs nothing that matters.
 func checkRemovable(w io.Writer) error {
 	if w == nil {
 		return errors.New("multiwriter: writer is nil")
 	}
-	if rt := reflect.TypeOf(w); !rt.Comparable() {
-		return fmt.Errorf("multiwriter: writer of type %s is not comparable, so it could never be removed", rt)
+	if !reflect.ValueOf(w).Comparable() {
+		return fmt.Errorf("multiwriter: writer of type %T is not comparable, so it could never be removed", w)
 	}
 	return nil
 }

--- a/io/writer.go
+++ b/io/writer.go
@@ -82,7 +82,9 @@ func (t *MultiWriter) Remove(writers ...io.Writer) {
 	t.writeMu.Lock()
 	defer t.writeMu.Unlock()
 
-	for i := len(t.writers) - 1; i > 0; i-- {
+	// Counts down to zero: the loop used to stop at 1, so whichever writer sat
+	// at index 0 could never be removed.
+	for i := len(t.writers) - 1; i >= 0; i-- {
 		for _, v := range writers {
 			if t.writers[i] == v {
 				t.writers = append(t.writers[:i], t.writers[i+1:]...)
@@ -92,21 +94,52 @@ func (t *MultiWriter) Remove(writers ...io.Writer) {
 	}
 }
 
-func (t *MultiWriter) Write(p []byte) (n int, err error) {
+// Write fans p out to every attached writer. It always reports success.
+//
+// Two things here are deliberate, and both were bugs.
+//
+// The writers are snapshotted under the lock and written to with the lock
+// released. Holding it across the writes made Append and Remove wait on
+// whatever the slowest attached writer was doing, and a guest that stops
+// reading its SSH channel blocks in Write indefinitely once the channel window
+// fills. That wedged the host: HandleSession removes its writer on the way out,
+// so Remove blocked, HandleSession never returned, and the client-left event it
+// emits on the way out was never sent. It also meant one stuck guest stopped
+// output reaching every other guest and the host's own terminal.
+//
+// A failing writer is dropped rather than reported. This is a broadcast to
+// whoever is attached, and the producer is the host's pty: returning an error
+// aborted the io.Copy feeding it, which ended the command and tore down the
+// whole session. One guest losing its connection at the wrong moment must not
+// take the session with it. Errors used to abandon the rest of the slice too,
+// so a broken guest silenced everyone attached after it.
+//
+// A writer removed between the snapshot and the write still receives this one
+// write. That is harmless: it is a session on its way out.
+//
+// Still outstanding: the writes are serial, so a guest that has stopped reading
+// holds up the fan-out for everyone until its write returns. Fixing that needs
+// per-writer buffering, so that a guest which cannot keep up is dropped rather
+// than allowed to slow the session down. Tracked in owenthereal/upterm#524.
+func (t *MultiWriter) Write(p []byte) (int, error) {
 	t.buffer.Append(p)
 
 	t.writeMu.Lock()
-	defer t.writeMu.Unlock()
+	writers := make([]io.Writer, len(t.writers))
+	copy(writers, t.writers)
+	t.writeMu.Unlock()
 
-	for _, w := range t.writers {
-		n, err = w.Write(p)
-		if err != nil {
-			return
+	var failed []io.Writer
+	for _, w := range writers {
+		n, err := w.Write(p)
+		if err != nil || n != len(p) {
+			failed = append(failed, w)
 		}
-		if n != len(p) {
-			err = io.ErrShortWrite
-			return
-		}
+	}
+
+	// Drop what broke, so the next write does not retry it.
+	if len(failed) > 0 {
+		t.Remove(failed...)
 	}
 
 	return len(p), nil

--- a/io/writer_test.go
+++ b/io/writer_test.go
@@ -2,10 +2,13 @@ package io
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_MultiWriter(t *testing.T) {
@@ -46,4 +49,88 @@ func Test_MultiWriter(t *testing.T) {
 	assert.Equal("hello1hello2hello3hello4", w1.String())
 	assert.Equal("hello1hello2hello3", w2.String())
 	assert.Equal("hello2hello3hello4", w3.String())
+}
+
+// blockingWriter models a guest whose SSH channel window has filled because it
+// stopped reading: Write blocks until released.
+type blockingWriter struct{ release chan struct{} }
+
+func (b *blockingWriter) Write(p []byte) (int, error) {
+	<-b.release
+	return len(p), nil
+}
+
+type failingWriter struct{ writes int }
+
+func (f *failingWriter) Write(p []byte) (int, error) {
+	f.writes++
+	return 0, errors.New("guest went away")
+}
+
+// A stuck writer must not stop the session being modified around it.
+//
+// MultiWriter used to hold its lock across every write, so a guest that stopped
+// reading blocked Remove. The host removes its writer as HandleSession returns,
+// so HandleSession never returned and never emitted the client-left event that
+// is deferred behind it.
+func TestMultiWriterStuckWriterDoesNotBlockRemove(t *testing.T) {
+	stuck := &blockingWriter{release: make(chan struct{})}
+	defer close(stuck.release)
+
+	w := NewMultiWriter(1)
+	require.NoError(t, w.Append(stuck))
+
+	writing := make(chan struct{})
+	go func() { close(writing); _, _ = w.Write([]byte("shell output")) }()
+	<-writing
+
+	done := make(chan struct{})
+	go func() { defer close(done); w.Remove(stuck) }()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Remove blocked behind a stuck writer")
+	}
+}
+
+// A writer that fails must not fail the producer.
+//
+// The producer is the host's pty copy. Returning an error aborted it, which
+// ended the command and tore the session down, so one guest disconnecting at
+// the wrong moment killed everyone's session.
+func TestMultiWriterFailingWriterIsDroppedNotPropagated(t *testing.T) {
+	bad := &failingWriter{}
+	var good bytes.Buffer
+
+	w := NewMultiWriter(1)
+	require.NoError(t, w.Append(bad))
+	require.NoError(t, w.Append(&good))
+
+	n, err := w.Write([]byte("first"))
+	require.NoError(t, err, "a broken guest must not fail the host's output copy")
+	assert.Equal(t, len("first"), n)
+	assert.Equal(t, "first", good.String(), "a broken guest must not silence the writers after it")
+
+	_, err = w.Write([]byte("second"))
+	require.NoError(t, err)
+	assert.Equal(t, "firstsecond", good.String())
+	assert.Equal(t, 1, bad.writes, "a writer that failed should be dropped, not retried")
+}
+
+// Remove used to count down to index 1, so whatever sat at index 0 was stuck
+// there for the life of the session.
+func TestMultiWriterRemoveFirstWriter(t *testing.T) {
+	var first, second bytes.Buffer
+
+	w := NewMultiWriter(1)
+	require.NoError(t, w.Append(&first))
+	require.NoError(t, w.Append(&second))
+
+	w.Remove(&first)
+	_, err := w.Write([]byte("hello"))
+	require.NoError(t, err)
+
+	assert.Empty(t, first.String(), "the writer at index 0 should have been removed")
+	assert.Equal(t, "hello", second.String())
 }

--- a/io/writer_test.go
+++ b/io/writer_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"io"
+	"sync"
 	"testing"
 	"time"
 
@@ -52,10 +53,24 @@ func Test_MultiWriter(t *testing.T) {
 }
 
 // blockingWriter models a guest whose SSH channel window has filled because it
-// stopped reading: Write blocks until released.
-type blockingWriter struct{ release chan struct{} }
+// stopped reading: Write blocks until released. It closes entered first, so a
+// test can wait for the fan-out to actually reach a writer rather than for the
+// goroutine that will eventually call Write to be scheduled.
+type blockingWriter struct {
+	once    sync.Once
+	entered chan struct{}
+	release chan struct{}
+}
+
+func newBlockingWriter() *blockingWriter {
+	return &blockingWriter{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+}
 
 func (b *blockingWriter) Write(p []byte) (int, error) {
+	b.once.Do(func() { close(b.entered) })
 	<-b.release
 	return len(p), nil
 }
@@ -74,15 +89,18 @@ func (f *failingWriter) Write(p []byte) (int, error) {
 // so HandleSession never returned and never emitted the client-left event that
 // is deferred behind it.
 func TestMultiWriterStuckWriterDoesNotBlockRemove(t *testing.T) {
-	stuck := &blockingWriter{release: make(chan struct{})}
+	stuck := newBlockingWriter()
 	defer close(stuck.release)
 
 	w := NewMultiWriter(1)
 	require.NoError(t, w.Append(stuck))
 
-	writing := make(chan struct{})
-	go func() { close(writing); _, _ = w.Write([]byte("shell output")) }()
-	<-writing
+	go func() { _, _ = w.Write([]byte("shell output")) }()
+
+	// Wait for the fan-out to be inside the stuck writer, not merely for the
+	// writing goroutine to have started. Signalling from the caller side let
+	// Remove win the race and pass without ever exercising the bug.
+	<-stuck.entered
 
 	done := make(chan struct{})
 	go func() { defer close(done); w.Remove(stuck) }()
@@ -92,6 +110,64 @@ func TestMultiWriterStuckWriterDoesNotBlockRemove(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("Remove blocked behind a stuck writer")
 	}
+}
+
+// Concurrent producers must not reach the same writer at once.
+//
+// Most attached writers are not concurrency safe, and even one that is would
+// end up with two writes interleaved. Run under -race, two goroutines writing
+// into a shared bytes.Buffer report a data race if the fan-out is unserialized.
+func TestMultiWriterConcurrentWritesAreSerialized(t *testing.T) {
+	var shared bytes.Buffer
+
+	w := NewMultiWriter(1)
+	require.NoError(t, w.Append(&shared))
+
+	const (
+		producers = 4
+		writes    = 200
+	)
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for range producers {
+		wg.Go(func() {
+			<-start
+			for range writes {
+				_, _ = w.Write([]byte("chunk"))
+			}
+		})
+	}
+	close(start)
+	wg.Wait()
+
+	assert.Equal(t, producers*writes*len("chunk"), shared.Len(), "every write should land intact")
+}
+
+// sliceWriter is a legal io.Writer whose dynamic type cannot be compared, so
+// `t.writers[i] == v` inside Remove would panic on it.
+type sliceWriter []byte
+
+func (s sliceWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+// Append refuses a writer Remove could never match.
+//
+// Write removes the writers that failed it, so a non-comparable writer turns
+// an ordinary guest disconnect into a panic in the host's pty copy, which
+// takes the process down. Reporting it from Append keeps the failure at the
+// call that can still do something about it.
+func TestMultiWriterAppendRejectsUnremovableWriters(t *testing.T) {
+	w := NewMultiWriter(1)
+
+	require.Error(t, w.Append(sliceWriter(nil)), "a non-comparable writer should be refused")
+	require.Error(t, w.Append(nil), "a nil writer should be refused")
+
+	var good bytes.Buffer
+	require.NoError(t, w.Append(&good))
+
+	_, err := w.Write([]byte("hello"))
+	require.NoError(t, err)
+	assert.Equal(t, "hello", good.String(), "a refused writer should not have been attached")
 }
 
 // A writer that fails must not fail the producer.

--- a/io/writer_test.go
+++ b/io/writer_test.go
@@ -150,6 +150,18 @@ type sliceWriter []byte
 
 func (s sliceWriter) Write(p []byte) (int, error) { return len(p), nil }
 
+type funcWriter func(p []byte) (int, error)
+
+func (f funcWriter) Write(p []byte) (int, error) { return f(p) }
+
+// wrappedWriter hides the problem one level down. Its type is comparable --
+// a struct with an interface field is -- so a check that asks the type says
+// yes, and the comparison inside Remove panics anyway when the writers it
+// holds are funcs. Decorators shaped exactly like this are ordinary: the host
+// attaches one, TerminalQueryFilter, and it is only safe because it is
+// attached by pointer.
+type wrappedWriter struct{ io.Writer }
+
 // Append refuses a writer Remove could never match.
 //
 // Write removes the writers that failed it, so a non-comparable writer turns
@@ -157,17 +169,47 @@ func (s sliceWriter) Write(p []byte) (int, error) { return len(p), nil }
 // takes the process down. Reporting it from Append keeps the failure at the
 // call that can still do something about it.
 func TestMultiWriterAppendRejectsUnremovableWriters(t *testing.T) {
+	discard := funcWriter(func(p []byte) (int, error) { return len(p), nil })
+
+	tests := []struct {
+		name   string
+		writer io.Writer
+	}{
+		{name: "nil", writer: nil},
+		{name: "slice", writer: sliceWriter(nil)},
+		{name: "func", writer: discard},
+		{name: "struct wrapping a func writer", writer: wrappedWriter{discard}},
+		{name: "struct wrapping a slice writer", writer: wrappedWriter{sliceWriter(nil)}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Error(t, NewMultiWriter(1).Append(tt.writer))
+		})
+	}
+}
+
+// The check is on the value, so it must not turn away a writer that is
+// perfectly removable. A decorator holding a pointer is the shape the host
+// actually attaches, and rejecting it would stop guests joining at all.
+func TestMultiWriterAppendAcceptsComparableWrappers(t *testing.T) {
+	var inner bytes.Buffer
+	wrapped := wrappedWriter{&inner}
+
 	w := NewMultiWriter(1)
-
-	require.Error(t, w.Append(sliceWriter(nil)), "a non-comparable writer should be refused")
-	require.Error(t, w.Append(nil), "a nil writer should be refused")
-
-	var good bytes.Buffer
-	require.NoError(t, w.Append(&good))
+	require.NoError(t, w.Append(wrapped))
 
 	_, err := w.Write([]byte("hello"))
 	require.NoError(t, err)
-	assert.Equal(t, "hello", good.String(), "a refused writer should not have been attached")
+	assert.Equal(t, "hello", inner.String())
+
+	// Removal is where an unremovable writer would have panicked, and Write
+	// does it unprompted for any writer that fails, so this is the half of
+	// the invariant that keeps the panic out of the host's pty copy.
+	w.Remove(wrapped)
+	_, err = w.Write([]byte("gone"))
+	require.NoError(t, err)
+	assert.Equal(t, "hello", inner.String(), "the wrapper should have been removable by identity")
 }
 
 // A writer that fails must not fail the producer.

--- a/server/sshd.go
+++ b/server/sshd.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/charmbracelet/ssh"
+	"charm.land/ssh"
 	"github.com/go-kit/kit/metrics"
 	"github.com/go-kit/kit/metrics/provider"
 	"github.com/owenthereal/upterm/internal/version"

--- a/server/sshhandler.go
+++ b/server/sshhandler.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/charmbracelet/ssh"
+	"charm.land/ssh"
 	"github.com/oklog/run"
 	gossh "golang.org/x/crypto/ssh"
 	"log/slog"

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -9,8 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	gssh "charm.land/ssh"
 	"github.com/adrg/xdg"
-	gssh "github.com/charmbracelet/ssh"
 	"github.com/dchest/uniuri"
 	"golang.org/x/crypto/ssh"
 )


### PR DESCRIPTION
Groundwork for removing the sshpiper fork, plus the fixes that fell out of writing the tests for it. Design in `docs/superpowers/specs/2026-09-07-remove-sshpiper-design.md` (kept untracked).

Does **not** remove the `golang.org/x/crypto` replace — that's the front-door rewrite, which this exists to make safe.

### Drop the sftp replace directive, and send canonical SFTP paths

Removes one of the two `replace` directives blocking `go install` ([#511](https://github.com/owenthereal/upterm/issues/511)).

The `github.com/owenthereal/sftp` fork carried [pkg/sftp#644](https://github.com/pkg/sftp/pull/644), which swaps `path.IsAbs` for `filepath.IsAbs` in `cleanPathWithBase`. That patch is wrong, and the bug it worked around was ours.

SFTP wire paths are POSIX on every platform — a Windows server exposes `C:\dir` as `/C:/dir`. `filepath.IsAbs` is platform-aware and on Windows requires a volume name, so it reports `false` for every path without a drive letter. Running Go's `volumeNameLen`/`IsAbs` from `internal/filepathlite/path_windows.go` against both versions:

| base | `p` | upstream | with #644 |
| --- | --- | --- | --- |
| `/` | `C:\a` | `/C:/a` | `C:/a` |
| `/C:/Users/foo` | `/C:/Users/foo/test.txt` | `/C:/Users/foo/test.txt` | `/C:/Users/foo/C:/Users/foo/test.txt` |
| `/start` | `/abs/path` | `/abs/path` | `/start/abs/path` |

Row 1 breaks pkg/sftp's own `TestCleanPath`. Row 2 reintroduces the doubling #644 sets out to fix, for the canonical wire form. Row 3 re-roots every absolute remote path under the session's start directory — exactly how upterm runs its SFTP server.

The real trigger was client-side: `Client.Open` sends paths verbatim (`client.go` has no `filepath` reference), and these tests passed `filepath.Join(t.TempDir(), ...)`, so on Windows the wire carried a native `C:\...` path. Tests now encode paths the way the protocol expects, so the fork is unnecessary. The two are the same code — `v1.13.10` is commit `939b203`, and the fork's base is two commits ahead, both an x/crypto bump.

### Add channel-proxy characterization tests, and a trustworthy baseline

The relay forwards decrypted SSH *packets* today, so channel numbering, windows, request ordering and close ordering survive untouched. A stock proxy terminates the channel layer on each side and re-originates everything, at which point each of those becomes a way to lose data silently. Eight cases across ssh/ws and single/multi-node, written against sshpiper first so a later failure means the rewrite broke something.

Three hazards are deliberately absent, with reasons in the file: stderr as a separate stream, stdin half-close, and a guest whose key the *host* rejects. upterm's guest surface can't reach them; they belong to the forwarder's unit tests.

Also replaces a wait in `testHostClientCallback` that failed roughly one full-suite run in five. Measured, the callback fires ~600µs after `Client.Close()` returns, so the 2s budget had three orders of magnitude of headroom — the test was using wall-clock as a proxy for causality. It now allows 10s, dumps goroutine stacks on timeout, and buffers the event channels.

### Report a forced command's exit code to the guest reliably

`HandleSession` read the exit status off `run.Group.Run`, which returns whichever actor finished first. When a forced command exits, two unblock at once: the wait carrying the status, and the output copy seeing the pty's EOF and returning nil. Measured with `--force-command 'exit 42'`: 42 in one of four topologies, 0 in the other three, same run.

Windows never reported the code at all — `pty.Wait` returned `fmt.Errorf("exit status %d")`, unparseable by the `*exec.ExitError` assertion, so every failing forced command surfaced as 1. Now a typed `*ExitError`. A status is used only when the process exited under its own control, since `exec` reports -1 for a signalled process and SSH marshals the status as a `uint32`.

Also stops falling through after rejecting a session with no pty.

### Move to charm.land/ssh v0.4.3

The import path moved to a vanity path on the same repo; it is not archived and has not been absorbed into `wish`. upterm was pinned to a 2025-08-26 pseudo-version, a year behind on the library that terminates SSH for every host, missing two merged data-race fixes. No API changes.

It does **not** fix the `sess.pty` race, still present in v0.4.3 and reported upstream as charmbracelet/ssh#58 with a fix in charmbracelet/ssh#59. `testProxyWindowChange` orders the two accesses in the meantime.

### Verification

`go build` (darwin + windows), `go vet`, unit suite, and ftests green with `-race`, 11 consecutive runs.

Two things I could not check locally, which is why this is a PR:

- **Windows.** The path table above is Go's Windows logic executed on darwin, not a Windows test run. `Test (Windows)` covers `./ftests/` unskipped, so this run is the real check.
- **One unreproduced hang.** During verification the ftests hung once and hit the 15-minute test timeout. Eleven runs since have been green at ~55s and I have no stack trace, so the cause is unknown and may predate this branch. Flagging rather than calling the suite clean.
