### PR TITLE
Keep PROXY headers optional for internal SSH hops

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -175,7 +175,14 @@ func Start(ctx context.Context, opt Opt, logger *slog.Logger) error {
 		if opt.SSHProxyProtocol {
 			// Wrap the SSH listener with proxyproto.Listener to preserve the real client IP
 			// when connections are coming through a TCP proxy (e.g., AWS ELB, HAProxy).
-			sshln = &proxyproto.Listener{Listener: sshln}
+			// Internal node hops and the WebSocket bridge use plain SSH on
+			// this same listener, so PROXY headers must remain optional.
+			sshln = &proxyproto.Listener{
+				Listener: sshln,
+				ConnPolicy: func(proxyproto.ConnPolicyOptions) (proxyproto.Policy, error) {
+					return proxyproto.USE, nil
+				},
+			}
 		}
 	}
 

--- a/server/server_proxy_protocol_test.go
+++ b/server/server_proxy_protocol_test.go
@@ -1,0 +1,143 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/owenthereal/upterm/upterm"
+	"github.com/owenthereal/upterm/ws"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+	"google.golang.org/protobuf/proto"
+)
+
+// Capture the bound address and the connection's observed peer address from
+// Start without adding a listener injection hook to production code.
+type proxyProtocolTestLogs chan map[string]any
+
+func (logs proxyProtocolTestLogs) Write(p []byte) (int, error) {
+	var record map[string]any
+	if err := json.Unmarshal(p, &record); err != nil {
+		return 0, err
+	}
+	select {
+	case logs <- record:
+	default:
+	}
+	return len(p), nil
+}
+
+func TestStartSSHProxyProtocolOptional(t *testing.T) {
+	t.Setenv("PRIVATE_KEY", "")
+	keyPath := filepath.Join(t.TempDir(), "host_key")
+	require.NoError(t, os.WriteFile(keyPath, []byte(TestPrivateKeyContent), 0600))
+	signer, err := ssh.ParsePrivateKey([]byte(TestPrivateKeyContent))
+	require.NoError(t, err)
+
+	logs := make(proxyProtocolTestLogs, 128)
+	logger := slog.New(slog.NewJSONHandler(logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- Start(ctx, Opt{
+			SSHAddr:          "127.0.0.1:0",
+			WSAddr:           "127.0.0.1:0",
+			SSHProxyProtocol: true,
+			HandshakeTimeout: 4 * time.Second,
+			PrivateKeys:      []string{keyPath},
+			Network:          "mem",
+		}, logger)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Error("server did not stop")
+		}
+	})
+	awaitLog := func(t *testing.T, message string) map[string]any {
+		t.Helper()
+		timer := time.NewTimer(5 * time.Second)
+		defer timer.Stop()
+		for {
+			select {
+			case record := <-logs:
+				if record["msg"] == message {
+					return record
+				}
+			case <-timer.C:
+				t.Fatalf("server did not log %q", message)
+			}
+		}
+	}
+	started := awaitLog(t, "starting server")
+	addr := started["ssh_addr"].(string)
+	wsAddr := started["ws_addr"].(string)
+
+	for _, transport := range []string{"plain_ssh", "proxy_header", "websocket"} {
+		t.Run(transport, func(t *testing.T) {
+			var raw net.Conn
+			if transport == "websocket" {
+				raw, err = ws.NewWSConn(&url.URL{Scheme: "ws", Host: wsAddr, User: url.UserPassword("proxy-policy-test", "")}, false)
+			} else {
+				raw, err = net.DialTimeout("tcp", addr, time.Second)
+			}
+			require.NoError(t, err)
+			defer func() { _ = raw.Close() }()
+			require.NoError(t, raw.SetDeadline(time.Now().Add(5*time.Second)))
+			wantAddr := raw.LocalAddr().String()
+			if transport == "proxy_header" {
+				wantAddr = "203.0.113.42:54321"
+				_, err = io.WriteString(raw, "PROXY TCP4 203.0.113.42 127.0.0.1 54321 2222\r\n")
+				require.NoError(t, err)
+			}
+			defer func() {
+				_ = raw.Close()
+				record := awaitLog(t, "SSH connection ended")
+				observed := record["addr"].(map[string]any)
+				if transport == "websocket" {
+					require.Equal(t, "127.0.0.1", observed["IP"], "WebSocket must reach the SSH listener over loopback")
+				} else {
+					require.Equal(t, wantAddr, net.JoinHostPort(observed["IP"].(string), fmt.Sprint(observed["Port"])),
+						"the server must retain the socket peer or the PROXY header's source address")
+				}
+			}()
+			conn, channels, requests, err := ssh.NewClientConn(raw, addr, &ssh.ClientConfig{
+				User:            "proxy-policy-test",
+				ClientVersion:   upterm.HostSSHClientVersion,
+				Auth:            []ssh.AuthMethod{ssh.PublicKeys(signer)},
+				HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+			})
+			require.NoError(t, err, "SSH must authenticate with or without a PROXY header")
+			client := ssh.NewClient(conn, channels, requests)
+			defer func() { _ = client.Close() }()
+			// Only sshd can successfully create a session; the relay's upstream
+			// failure path can reject requests but cannot produce this response.
+			request, err := proto.Marshal(&CreateSessionRequest{
+				HostUser:       "proxy-policy-test",
+				HostPublicKeys: [][]byte{[]byte(TestPublicKeyContent)},
+			})
+			require.NoError(t, err)
+			ok, body, err := client.SendRequest(upterm.ServerCreateSessionRequestType, true, request)
+			require.NoError(t, err)
+			require.True(t, ok, "sshd must create the session: %s", body)
+			var response CreateSessionResponse
+			require.NoError(t, proto.Unmarshal(body, &response))
+			require.NotEmpty(t, response.SessionID)
+			require.NotEmpty(t, response.SshUser)
+			require.Equal(t, addr, response.NodeAddr)
+			// Disconnecting also removes this connection's session at sshd.
+			require.NoError(t, client.Close())
+		})
+	}
+}


### PR DESCRIPTION
With `--ssh-proxy-protocol` enabled, the shared SSH listener rejected the plain SSH connections used by cross-node routing and the WebSocket bridge. `go-proxyproto v0.15.0` defaults to requiring a PROXY header, while the listener relied on that default.

Set an explicit per-listener `USE` policy to preserve the previous optional-header behavior: public proxy connections still supply the original client address, and internal plain SSH connections work. The routing hops and authentication behavior are unchanged.

The regression starts the production server with PROXY support enabled and covers plain SSH, a valid PROXY header with exact source-address preservation, and WebSocket through the real loopback bridge. Each path must authenticate and successfully create a session at the upstream sshd.

This was found during v0.25.0 rollout verification after #526: public SSH/SFTP passed for old and new clients, but private SSH and WebSocket failed. The relay was rolled back to the previous image and configuration; WebSocket and SJC-to-IAD sessions passed again. The fix shipped in v0.25.1 and is deployed at exact revision `bdc1ebe` across SJC, IAD and FRA. All three nodes pass health checks and plain SSH, with Consul routing confirmed at startup.

Validation: full local `make test` with the race detector and Consul passes (functional package 114.979s), followed by 30 passing race-enabled repetitions of the strengthened positive-service regression. Lint reports zero issues and final review has no open findings. The original regression reproduced plain-SSH and WebSocket failures before the policy fix. A complete bidirectional WebSocket terminal session also passes locally with PROXY support enabled. All 11 CI checks pass on `b6b1dcb`, including native Windows/macOS/Ubuntu+Consul, E2E, CodeQL and snapshot packaging. No characterization test or forwarder code changes.

Post-deployment validation: released v0.24.0 and v0.25.1 clients each pass nine public SSH/SFTP cases and bidirectional public WebSocket. Forced IAD-to-FRA, FRA-to-SJC and SJC-to-IAD sessions pass; the last remained connected for five minutes with 19 successful traffic/metric samples. Session gauges and host/client authentication counters behave correctly across the three regions. Default-proxy module-root `go install ...@latest` also succeeds for v0.25.1. This is the authorized bounded observation, not an extended soak.
