### PR TITLE
Exercise WebSocket CLI sync in Go E2E tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -115,10 +115,10 @@ jobs:
       - name: Build and start uptermd
         run: |
           go build -o /tmp/uptermd/uptermd ./cmd/uptermd
-          /tmp/uptermd/uptermd --ssh-addr 127.0.0.1:2222 --private-key /tmp/uptermd/id_ed25519 > /tmp/uptermd/uptermd.log 2>&1 &
+          /tmp/uptermd/uptermd --ssh-addr 127.0.0.1:2222 --ws-addr 127.0.0.1:8080 --ssh-proxy-protocol --private-key /tmp/uptermd/id_ed25519 > /tmp/uptermd/uptermd.log 2>&1 &
           echo "Waiting for uptermd to start..."
           for i in $(seq 1 30); do
-            if nc -z 127.0.0.1 2222 2>/dev/null; then
+            if nc -z 127.0.0.1 2222 2>/dev/null && nc -z 127.0.0.1 8080 2>/dev/null; then
               echo "uptermd is ready"
               break
             fi
@@ -134,6 +134,11 @@ jobs:
         run: make test-e2e
         env:
           UPTERM_E2E_SERVER: ssh://127.0.0.1:2222
+
+      - name: Run WebSocket sync E2E test
+        run: make test-e2e GO_TEST_FLAGS='-run TestSync'
+        env:
+          UPTERM_E2E_SERVER: ws://127.0.0.1:8080
 
       - name: Cleanup uptermd
         if: always()

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -221,8 +221,8 @@ func extractSSHCommand(output string) string {
 	// Remove newlines/extra spaces caused by terminal wrapping
 	clean = regexp.MustCompile(`\s+`).ReplaceAllString(clean, " ")
 
-	// Match ssh command with optional -p port
-	re := regexp.MustCompile(`SSH:\s*(ssh\s+\S+(?:\s+-p\s+\d+)?)`)
+	// Preserve the quoted WebSocket ProxyCommand and optional SSH port.
+	re := regexp.MustCompile(`SSH:\s*(ssh\s+(?:-o\s+ProxyCommand='[^']+'\s+)?\S+(?:\s+-p\s+\d+)?)`)
 	matches := re.FindStringSubmatch(clean)
 	if len(matches) < 2 {
 		return ""


### PR DESCRIPTION
The E2E harness truncated advertised WebSocket commands to `ssh -o`, so it could not exercise the real CLI/OpenSSH WebSocket path. Preserve the quoted `ProxyCommand` and reuse the existing Go `TestSync` over WebSocket in CI. The local CI relay enables PROXY support and waits for both SSH and WebSocket listeners; the existing nine SSH/SFTP cases continue to run.

No additional test body, Python verifier, dependency, or production code is introduced.

Validation: the unchanged `TestSync` failed over WebSocket before the parser fix with OpenSSH's missing-option error, then passed with traffic in both directions. All nine SSH/SFTP E2E cases pass after the change, and `golangci-lint run ./internal/e2e/...` reports zero issues.

All 11 CI checks pass on `63973ae`, including native Windows/macOS/Ubuntu+Consul, E2E, vet, CodeQL and snapshot packaging. The Linux job log confirms the existing nine SSH/SFTP cases passed, followed by the actual WebSocket `TestSync` (0.77s, not skipped). Independent review has no open findings.
