### PR TITLE
Document ordering guarantees in the stock SSH forwarder; test session completion and OpenSSH guests

### DIFF
--- a/ftests/ftests_test.go
+++ b/ftests/ftests_test.go
@@ -954,6 +954,15 @@ func writeTempFile(name, content string) (string, error) {
 		_ = file.Close()
 	}()
 
+	// The OpenSSH private key literals above end right after "-----END
+	// OPENSSH PRIVATE KEY-----" with no trailing newline. x/crypto's key
+	// parser tolerates that, but OpenSSH's own key loader rejects the file
+	// outright ("invalid format"), and ftests hands these keys to the real
+	// ssh binary as well as to x/crypto clients.
+	if !strings.HasSuffix(content, "\n") {
+		content += "\n"
+	}
+
 	if _, err := file.Write([]byte(content)); err != nil {
 		return "", err
 	}

--- a/ftests/proxy_test.go
+++ b/ftests/proxy_test.go
@@ -379,8 +379,11 @@ func testProxyWindowChange(t *testing.T, hostShareURL, hostNodeAddr, clientJoinU
 	// first, and getting that backwards is a live hazard in this area.
 	require.NoError(t, c.session.WindowChange(24, 120))
 
-	// WindowChange has no reply: stdin can reach stty before the host applies
-	// the resize. Take fresh samples until the exact requested size is seen.
+	// This checks eventual resize application. The proxy relays requests and
+	// data independently, and the host applies window events separately from
+	// copying stdin to the pty. WindowChange has no acknowledgement of that
+	// application, so a following stty can still see the old size. Sampling
+	// again tests resize delivery, not the proxy's packet ordering.
 	retry := time.NewTicker(50 * time.Millisecond)
 	defer retry.Stop()
 	for {

--- a/ftests/proxy_test.go
+++ b/ftests/proxy_test.go
@@ -3,12 +3,15 @@ package ftests
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
 	"io"
+	"net"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -48,11 +51,19 @@ import (
 //     never sees a key it will refuse. testClientAuthorizedKeyNotMatching
 //     covers the relay-rejects case, which is the one that happens today.
 //
+// One case here does not use a Go client at all:
+// testProxyStockSSHClientTrailingOutput drives the system ssh binary, because
+// that is what README tells a guest to run and because a client that stopped
+// reading on exit-status would truncate output in a way no x/crypto client
+// test in this package can see. It skips where that binary or a direct ssh
+// endpoint is unavailable.
+//
 // All three belong to the forwarder's own unit tests, against a stock SSH
 // server and client with no upterm involved.
 var ProxyTestCases = []FtestCase{
 	testProxyExitStatus,
 	testProxyForcedCommandExitStatus,
+	testProxyStockSSHClientTrailingOutput,
 	testProxyLargeTransfer,
 	testProxyWindowChange,
 	testProxyPreShellRequests,
@@ -122,6 +133,139 @@ func shareHost(t *testing.T, h *Host, hostShareURL, hostNodeAddr string) *api.Ge
 	t.Cleanup(h.Close)
 
 	return getAndVerifySession(t, h.AdminSocketFile, hostShareURL, hostNodeAddr)
+}
+
+// requireStockSSH skips unless the system ssh binary can reach this topology,
+// and returns its path.
+//
+// The ws topologies would need `upterm proxy` as a ProxyCommand, which means
+// building and locating the CLI from a test. The ssh topologies are exactly
+// what README.md:77 tells a guest to type, and they are what this case is
+// about, so restricting to them costs no coverage that matters.
+func requireStockSSH(t *testing.T, clientJoinURL string) string {
+	t.Helper()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("stock ssh guest case is POSIX-only")
+	}
+
+	u, err := url.Parse(clientJoinURL)
+	require.NoError(t, err)
+	if u.Scheme != "ssh" {
+		t.Skipf("stock ssh guest needs a direct ssh endpoint, got scheme %q", u.Scheme)
+	}
+
+	path, err := exec.LookPath("ssh")
+	if err != nil {
+		t.Skip("no ssh binary on PATH")
+	}
+	return path
+}
+
+// stockSSHGuestArgs builds the argv a guest would type, minus the binary.
+//
+// -tt forces a pty even though the test's stdin is not a terminal: upterm
+// rejects a session without one. IdentitiesOnly keeps a developer's running
+// agent from offering a key the session does not permit, which would surface
+// as an auth failure that has nothing to do with this case.
+//
+// ClientPrivateKey (the shared fixture every Go-client case in this package
+// dials with) is unusable here: its raw string literal ends right after
+// "-----END OPENSSH PRIVATE KEY-----" with no trailing newline, which
+// x/crypto's parser tolerates but OpenSSH's own key loader does not --
+// `ssh -i` on it fails closed with "invalid format" before a connection is
+// even attempted. Write a copy with the newline restored for the stock
+// client to use instead.
+func stockSSHGuestArgs(t *testing.T, session *api.GetSessionResponse, clientJoinURL string) []string {
+	t.Helper()
+
+	u, err := url.Parse(clientJoinURL)
+	require.NoError(t, err)
+
+	hostname, port, err := net.SplitHostPort(u.Host)
+	require.NoError(t, err)
+
+	keyPath := filepath.Join(t.TempDir(), "id_ed25519")
+	require.NoError(t, os.WriteFile(keyPath, []byte(ClientPrivateKeyContent+"\n"), 0600))
+
+	return []string{
+		"-tt",
+		"-p", port,
+		"-i", keyPath,
+		"-o", "IdentitiesOnly=yes",
+		"-o", "StrictHostKeyChecking=no",
+		"-o", "UserKnownHostsFile=" + os.DevNull,
+		"-o", "BatchMode=yes",
+		"-o", "LogLevel=ERROR",
+		session.SshUser + "@" + hostname,
+	}
+}
+
+// trailingOutputCommand writes lines numbered from zero and then exits, with
+// nothing in between, so exit-status is sent while output is still in flight.
+func trailingOutputCommand(lines, code int) []string {
+	return []string{"bash", "-c", fmt.Sprintf(
+		`i=0; while [ $i -lt %d ]; do printf 'line-%%06d\n' $i; i=$((i+1)); done; exit %d`,
+		lines, code)}
+}
+
+// testProxyStockSSHClientTrailingOutput joins with the system ssh binary and
+// checks that output written immediately before exit arrives complete.
+//
+// README.md:77 documents `ssh TOKEN@uptermd.upterm.dev` as the way to join, so
+// OpenSSH is the default guest, not an exotic one. exit-status is a channel
+// request and can overtake buffered stdout inside the forwarder; the forwarder
+// only guarantees that forwarded data precedes CLOSE. So a guest that stopped
+// reading on exit-status would truncate here, and every Go-client test in this
+// package would still pass. This is the case that says it does not.
+func testProxyStockSSHClientTrailingOutput(t *testing.T, hostShareURL, hostNodeAddr, clientJoinURL string) {
+	// 200k lines of 12 bytes plus the pty's \r is ~2.6 MB, comfortably past
+	// x/crypto's 2 MB channel window, so output is still being forwarded when
+	// the command exits.
+	const (
+		wantLines = 200000
+		wantCode  = 42
+	)
+
+	sshPath := requireStockSSH(t, clientJoinURL)
+
+	adminSocketFile := setupAdminSocket(t)
+	session := shareHost(t, &Host{
+		Command:                  getTestShell(),
+		ForceCommand:             trailingOutputCommand(wantLines, wantCode),
+		PrivateKeys:              []string{HostPrivateKey},
+		AdminSocketFile:          adminSocketFile,
+		PermittedClientPublicKey: ClientPublicKeyContent,
+	}, hostShareURL, hostNodeAddr)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, sshPath, stockSSHGuestArgs(t, session, clientJoinURL)...)
+
+	// Hold the guest's stdin open. ssh forwards its own stdin EOF, and the
+	// host ends the session on stdin EOF, so /dev/null would race the forced
+	// command's output. Nothing is ever written; cmd.Wait closes it.
+	stdin, err := cmd.StdinPipe()
+	require.NoError(t, err)
+	defer func() { _ = stdin.Close() }()
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+
+	runErr := cmd.Run()
+	require.NoError(t, ctx.Err(), "stock ssh guest timed out; stderr: %s", stderr.String())
+
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, runErr, &exitErr,
+		"expected the forced command's exit code, got %v; stderr: %s", runErr, stderr.String())
+	assert.Equal(t, wantCode, exitErr.ExitCode(), "forced command's exit code should reach the stock ssh guest")
+
+	out := stdout.String()
+	assert.Equal(t, wantLines, strings.Count(out, "line-"),
+		"every line written before the exit should reach the stock ssh guest")
+	assert.Contains(t, out, fmt.Sprintf("line-%06d", wantLines-1),
+		"the last line written before the exit should not be truncated by an early close")
 }
 
 // testProxyExitStatus pins that an exit status, and the output that precedes

--- a/ftests/proxy_test.go
+++ b/ftests/proxy_test.go
@@ -29,14 +29,15 @@ import (
 // ProxyTestCases pins the behaviour of the relay's front door at the SSH
 // connection-protocol layer.
 //
-// The relay forwards decrypted SSH *packets* today, so channel numbering,
-// windows, request ordering and close ordering all survive untouched and none
-// of the cases below can fail for a reason the front door is responsible for.
-// Replacing it with a stock golang.org/x/crypto proxy terminates the channel
-// layer on each side and re-originates every channel and every request, at
-// which point each of these becomes a way to lose data silently. They are
-// written against the piper first so that a failure afterwards means the
-// rewrite broke something, rather than meaning the test was never right.
+// These were written against the old sshpiper relay, which forwarded decrypted
+// SSH *packets*: channel numbering, windows, request ordering and close
+// ordering all survived untouched, so none of the cases below could fail for a
+// reason the front door was responsible for. #526 replaced it with a stock
+// golang.org/x/crypto proxy (server/sshforward.go), which terminates the
+// channel layer on each side and re-originates every channel and every
+// request — at which point each of these became a way to lose data silently.
+// Writing them against the piper first means a failure now indicates the
+// rewrite broke something, rather than that the test was never right.
 //
 // Not covered here, deliberately, because upterm's guest surface cannot reach
 // them and a test that cannot fail is worse than no test:
@@ -140,7 +141,7 @@ func shareHost(t *testing.T, h *Host, hostShareURL, hostNodeAddr string) *api.Ge
 //
 // The ws topologies would need `upterm proxy` as a ProxyCommand, which means
 // building and locating the CLI from a test. The ssh topologies are exactly
-// what README.md:77 tells a guest to type, and they are what this case is
+// what README.md tells a guest to type, and they are what this case is
 // about, so restricting to them costs no coverage that matters.
 func requireStockSSH(t *testing.T, clientJoinURL string) string {
 	t.Helper()
@@ -201,7 +202,7 @@ func trailingOutputCommand(lines, code int) []string {
 // testProxyStockSSHClientTrailingOutput joins with the system ssh binary and
 // checks that output written immediately before exit arrives complete.
 //
-// README.md:77 documents `ssh TOKEN@uptermd.upterm.dev` as the way to join, so
+// README.md documents `ssh TOKEN@uptermd.upterm.dev` as the way to join, so
 // OpenSSH is the default guest, not an exotic one. exit-status is a channel
 // request and can overtake buffered stdout inside the forwarder; the forwarder
 // only guarantees that forwarded data precedes CLOSE. So a guest that stopped
@@ -212,8 +213,8 @@ func testProxyStockSSHClientTrailingOutput(t *testing.T, hostShareURL, hostNodeA
 	// one x/crypto channel window of total output, but the window bounds
 	// unacked bytes rather than cumulative volume, and a bash loop writing a
 	// line at a time never saturates it. What the volume buys is a backlog at
-	// exit: a guest that stopped reading on exit-status would lose hundreds of
-	// lines and miss the count below.
+	// exit: a guest that stopped reading on exit-status would lose whatever
+	// backlog is in flight and miss the count below.
 	const (
 		wantLines = 200000
 		wantCode  = 42

--- a/ftests/proxy_test.go
+++ b/ftests/proxy_test.go
@@ -169,6 +169,13 @@ func requireStockSSH(t *testing.T, clientJoinURL string) string {
 // rejects a session without one. IdentitiesOnly keeps a developer's running
 // agent from offering a key the session does not permit, which would surface
 // as an auth failure that has nothing to do with this case.
+//
+// -F os.DevNull is what isolates this from the developer's own ~/.ssh/config.
+// IdentitiesOnly does not do that job: it only governs which keys are offered.
+// A wildcard Host * block carrying ProxyCommand, ProxyJump or ControlMaster
+// would otherwise redirect or multiplex this connection and fail a healthy
+// test. Note the isolation is partial — OpenSSH still reads the system-wide
+// /etc/ssh/ssh_config and offers no flag to suppress it.
 func stockSSHGuestArgs(t *testing.T, session *api.GetSessionResponse, clientJoinURL string) []string {
 	t.Helper()
 
@@ -180,6 +187,7 @@ func stockSSHGuestArgs(t *testing.T, session *api.GetSessionResponse, clientJoin
 
 	return []string{
 		"-tt",
+		"-F", os.DevNull,
 		"-p", port,
 		"-i", ClientPrivateKey,
 		"-o", "IdentitiesOnly=yes",
@@ -203,18 +211,30 @@ func trailingOutputCommand(lines, code int) []string {
 // checks that output written immediately before exit arrives complete.
 //
 // README.md documents `ssh TOKEN@uptermd.upterm.dev` as the way to join, so
-// OpenSSH is the default guest, not an exotic one. exit-status is a channel
-// request and can overtake buffered stdout inside the forwarder; the forwarder
-// only guarantees that forwarded data precedes CLOSE. So a guest that stopped
-// reading on exit-status would truncate here, and every Go-client test in this
-// package would still pass. This is the case that says it does not.
+// OpenSSH is the default guest, not an exotic one, and every other case in
+// this package drives a Go x/crypto client.
+//
+// What this establishes: a real OpenSSH guest receives every byte and the exit
+// status through the relay, under a high-volume command that exits the instant
+// it stops writing.
+//
+// What it does NOT establish: that a client which stopped reading on
+// exit-status would fail here. exit-status is a channel request and can
+// overtake buffered stdout inside the forwarder, which guarantees only that
+// forwarded data precedes CLOSE — but this test never constructs that race. It
+// does not force output to be undelivered at the moment the status is
+// processed, and the guest drains continuously into memory, so the backlog at
+// exit is small and scheduling-dependent. The discriminating power against
+// that specific defect is unmeasured. Pinning it needs a host that withholds
+// the trailing bytes until the client has demonstrably processed the status,
+// which this harness cannot do: the host is a real upterm host running a real
+// shell, with no way to inject a channel request mid-stream.
 func testProxyStockSSHClientTrailingOutput(t *testing.T, hostShareURL, hostNodeAddr, clientJoinURL string) {
-	// 200k lines of 12 bytes plus the pty's \r is ~2.6 MB. That is more than
-	// one x/crypto channel window of total output, but the window bounds
-	// unacked bytes rather than cumulative volume, and a bash loop writing a
-	// line at a time never saturates it. What the volume buys is a backlog at
-	// exit: a guest that stopped reading on exit-status would lose whatever
-	// backlog is in flight and miss the count below.
+	// 200k lines of 12 bytes plus the pty's \r is ~2.6 MB. The volume makes a
+	// backlog at exit likely rather than certain: the window bounds unacked
+	// bytes rather than cumulative volume, and a bash loop writing a line at a
+	// time never saturates it. See the note above for what that does and does
+	// not buy.
 	const (
 		wantLines = 200000
 		wantCode  = 42

--- a/ftests/proxy_test.go
+++ b/ftests/proxy_test.go
@@ -51,15 +51,15 @@ import (
 //     never sees a key it will refuse. testClientAuthorizedKeyNotMatching
 //     covers the relay-rejects case, which is the one that happens today.
 //
+// All three belong to the forwarder's own unit tests, against a stock SSH
+// server and client with no upterm involved.
+//
 // One case here does not use a Go client at all:
 // testProxyStockSSHClientTrailingOutput drives the system ssh binary, because
 // that is what README tells a guest to run and because a client that stopped
 // reading on exit-status would truncate output in a way no x/crypto client
 // test in this package can see. It skips where that binary or a direct ssh
 // endpoint is unavailable.
-//
-// All three belong to the forwarder's own unit tests, against a stock SSH
-// server and client with no upterm involved.
 var ProxyTestCases = []FtestCase{
 	testProxyExitStatus,
 	testProxyForcedCommandExitStatus,
@@ -208,9 +208,12 @@ func trailingOutputCommand(lines, code int) []string {
 // reading on exit-status would truncate here, and every Go-client test in this
 // package would still pass. This is the case that says it does not.
 func testProxyStockSSHClientTrailingOutput(t *testing.T, hostShareURL, hostNodeAddr, clientJoinURL string) {
-	// 200k lines of 12 bytes plus the pty's \r is ~2.6 MB, comfortably past
-	// x/crypto's 2 MB channel window, so output is still being forwarded when
-	// the command exits.
+	// 200k lines of 12 bytes plus the pty's \r is ~2.6 MB. That is more than
+	// one x/crypto channel window of total output, but the window bounds
+	// unacked bytes rather than cumulative volume, and a bash loop writing a
+	// line at a time never saturates it. What the volume buys is a backlog at
+	// exit: a guest that stopped reading on exit-status would lose hundreds of
+	// lines and miss the count below.
 	const (
 		wantLines = 200000
 		wantCode  = 42

--- a/ftests/proxy_test.go
+++ b/ftests/proxy_test.go
@@ -168,14 +168,6 @@ func requireStockSSH(t *testing.T, clientJoinURL string) string {
 // rejects a session without one. IdentitiesOnly keeps a developer's running
 // agent from offering a key the session does not permit, which would surface
 // as an auth failure that has nothing to do with this case.
-//
-// ClientPrivateKey (the shared fixture every Go-client case in this package
-// dials with) is unusable here: its raw string literal ends right after
-// "-----END OPENSSH PRIVATE KEY-----" with no trailing newline, which
-// x/crypto's parser tolerates but OpenSSH's own key loader does not --
-// `ssh -i` on it fails closed with "invalid format" before a connection is
-// even attempted. Write a copy with the newline restored for the stock
-// client to use instead.
 func stockSSHGuestArgs(t *testing.T, session *api.GetSessionResponse, clientJoinURL string) []string {
 	t.Helper()
 
@@ -185,13 +177,10 @@ func stockSSHGuestArgs(t *testing.T, session *api.GetSessionResponse, clientJoin
 	hostname, port, err := net.SplitHostPort(u.Host)
 	require.NoError(t, err)
 
-	keyPath := filepath.Join(t.TempDir(), "id_ed25519")
-	require.NoError(t, os.WriteFile(keyPath, []byte(ClientPrivateKeyContent+"\n"), 0600))
-
 	return []string{
 		"-tt",
 		"-p", port,
-		"-i", keyPath,
+		"-i", ClientPrivateKey,
 		"-o", "IdentitiesOnly=yes",
 		"-o", "StrictHostKeyChecking=no",
 		"-o", "UserKnownHostsFile=" + os.DevNull,

--- a/server/sshforward.go
+++ b/server/sshforward.go
@@ -248,11 +248,35 @@ type sshForwardChannel struct {
 	replies sync.Mutex
 }
 
+// channelDirection forwards one direction of one channel. It preserves:
+//
+//   - Byte order within each stream. stdin, stdout and stderr are each a
+//     single io.Copy in copySSHChannel.
+//   - Request order within this direction. requests dispatches from one serial
+//     sender, so replies come back in the order the requests were sent, as
+//     RFC 4254 section 4 requires.
+//   - Forwarded data before CLOSE. requests returns, then streams.Wait(), and
+//     only then destination.Close(). Every forwarded byte has returned from
+//     its Write before CLOSE is written, and x/crypto serializes channel
+//     packets and refuses writes once CLOSE has gone out. A peer that reads
+//     until CHANNEL_CLOSE cannot be truncated by this forwarder.
+//
+// It does not preserve the relative order of ordinary data, extended data and
+// requests, and cannot: that information is already gone when we see it.
+// x/crypto delivers incoming requests on a buffered Go channel (chanSize = 16)
+// while data lands in a byte buffer, so its mux read loop runs ahead and
+// buffers post-request bytes before the request is dequeued. Nothing ties a
+// request to an offset in the byte stream, so sequencing here would order
+// goroutine observations rather than recover packet order. Callers that need
+// a resize applied before subsequent stdin cannot get it from the proxy alone;
+// the host applies window events and copies stdin in separate actors.
+//
 // Normal close waits until source data and requests have drained. An explicit
-// source CLOSE can instead abort a pending reply (see requests below). In particular, EOF
-// alone cannot close a channel: a command may still produce output and status
-// after stdin EOF. Treat either endpoint's CLOSE symmetrically so a caller can
-// close one channel without leaving its peer open for the connection's lifetime.
+// source CLOSE can instead abort a pending reply (see requests below). In
+// particular, EOF alone cannot close a channel: a command may still produce
+// output and status after stdin EOF. Treat either endpoint's CLOSE
+// symmetrically so a caller can close one channel without leaving its peer
+// open for the connection's lifetime.
 func (f sshForwarder) channelDirection(destination, source *sshForwardChannel, requests <-chan *ssh.Request) {
 	var streams sync.WaitGroup
 	streams.Go(func() { copySSHChannel(destination, source) })
@@ -265,6 +289,9 @@ func (f sshForwarder) channelDirection(destination, source *sshForwardChannel, r
 	_ = destination.Close()
 }
 
+// copySSHChannel copies ordinary data and extended data concurrently, so byte
+// order holds within each stream but not between them. See channelDirection.
+//
 // EOF covers both ordinary and extended data; sending it before stderr drains
 // would make subsequent stderr writes fail. CloseWrite preserves the other
 // direction, including output produced after the caller finishes writing stdin.

--- a/server/sshforward.go
+++ b/server/sshforward.go
@@ -255,17 +255,23 @@ type sshForwardChannel struct {
 //   - Request order within this direction. requests dispatches from one serial
 //     sender, so replies come back in the order the requests were sent, as
 //     RFC 4254 section 4 requires.
-//   - Forwarded data before CLOSE. requests returns, then streams.Wait(), and
-//     only then destination.Close(). Every forwarded byte has returned from
-//     its Write before CLOSE is written, and x/crypto serializes channel
-//     packets and refuses writes once CLOSE has gone out. A peer that reads
-//     until CHANNEL_CLOSE cannot be truncated by this forwarder.
+//   - Forwarded data before CLOSE, on the ordinary path. requests returns,
+//     then streams.Wait(), and only then destination.Close(). Every forwarded
+//     byte has returned from its Write before CLOSE is written, and x/crypto
+//     serializes channel packets and refuses writes once CLOSE has gone out,
+//     so a peer reading until CHANNEL_CLOSE is not truncated here. The aborts
+//     are the exception: abortPending closes destination from inside requests,
+//     before streams.Wait(), and cancellation, request-queue overflow and
+//     sshForwardDrainTimeout close both transports outright. Each of those can
+//     cut a Write that has not returned, and copySSHChannel discards the error.
+//   - EOF before CLOSE, and half-close survives. See copySSHChannel.
 //
 // It does not preserve the relative order of ordinary data, extended data and
 // requests, and cannot: that information is already gone when we see it.
-// x/crypto delivers incoming requests on a buffered Go channel (chanSize = 16)
-// while data lands in a byte buffer, so its mux read loop runs ahead and
-// buffers post-request bytes before the request is dequeued. Nothing ties a
+// x/crypto delivers incoming requests on a buffered Go channel (chanSize = 16,
+// handshake.go:26 at v0.55.0) while data lands in a byte buffer, so its mux
+// read loop runs ahead and buffers post-request bytes before the request is
+// dequeued. Nothing ties a
 // request to an offset in the byte stream, so sequencing here would order
 // goroutine observations rather than recover packet order. Callers that need
 // a resize applied before subsequent stdin cannot get it from the proxy alone;

--- a/server/sshforward_stockclient_test.go
+++ b/server/sshforward_stockclient_test.go
@@ -1,0 +1,241 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"runtime"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// requireStockSSHBinary skips unless a system ssh binary is usable here.
+func requireStockSSHBinary(t *testing.T) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("stock ssh client case is POSIX-only")
+	}
+	path, err := exec.LookPath("ssh")
+	if err != nil {
+		t.Skip("no ssh binary on PATH")
+	}
+	return path
+}
+
+// stockSSHClientArgs isolates the invocation from the developer's environment.
+// -F os.DevNull is the part that matters: a wildcard Host * block carrying
+// ProxyCommand, ProxyJump or ControlMaster would otherwise redirect this
+// connection. OpenSSH still reads /etc/ssh/ssh_config and gives no way to
+// suppress it, so the isolation is good rather than total. -T keeps the session
+// pty-free: this server answers requests without allocating one, and a pty
+// would add CR translation between the bytes written and the bytes asserted.
+func stockSSHClientArgs(addr string) []string {
+	host, port, _ := net.SplitHostPort(addr)
+	return []string{
+		"-T",
+		"-F", os.DevNull,
+		"-p", port,
+		"-o", "StrictHostKeyChecking=no",
+		"-o", "UserKnownHostsFile=" + os.DevNull,
+		"-o", "BatchMode=yes",
+		"-o", "PreferredAuthentications=none,password",
+		"-o", "LogLevel=ERROR",
+		"test@" + host,
+		"irrelevant-command",
+	}
+}
+
+// forwardTestStockClientHost accepts one real ssh client on a loopback
+// listener, forwards it through forwardSSH, and returns the address to dial
+// plus the peer standing in for the host at the far end.
+func forwardTestStockClientHost(t *testing.T) (string, sshPeer) {
+	t.Helper()
+
+	_, private, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer, err := ssh.NewSignerFromKey(private)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serverConfig := &ssh.ServerConfig{NoClientAuth: true}
+	serverConfig.AddHostKey(signer)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	upstream, host := forwardTestPair(t, nil, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	stopped := make(chan struct{})
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-stopped:
+		case <-time.After(5 * time.Second):
+			t.Error("forwarder workers did not drain")
+		}
+	})
+
+	go func() {
+		defer close(stopped)
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		serverConn, channels, requests, err := ssh.NewServerConn(conn, serverConfig)
+		if err != nil {
+			_ = conn.Close()
+			return
+		}
+		_ = forwardSSH(ctx, sshPeer{serverConn, channels, requests}, upstream)
+	}()
+
+	return listener.Addr().String(), host
+}
+
+// TestSSHForwardStockSSHClientReadsPastExitStatus pins that a real OpenSSH
+// client keeps delivering channel data it receives after exit-status, through
+// forwardSSH.
+//
+// This is the discriminating version of the functional case in
+// ftests/proxy_test.go. That one writes a large volume and exits immediately,
+// which shows OpenSSH works in a realistic scenario but never constructs the
+// race: nothing there forces output to be undelivered at the instant the
+// status is processed, so a client that quit on exit-status could still pass.
+//
+// Here the host withholds the trailing bytes until the client has demonstrably
+// processed the status. exit-status is followed by an unknown channel request
+// with want_reply; OpenSSH answers unknown requests with CHANNEL_FAILURE, and
+// channel requests are processed in order, so that reply is proof the client
+// consumed the status. Only then does the host send the tail. A client that
+// treated exit-status as end-of-session drops the tail and fails the assertion
+// below; one that quit outright never answers the probe and trips its timeout.
+//
+// Detection power was measured rather than assumed: withholding the tail write
+// makes this fail with "client output 4096 bytes, want 8192 ... tail present:
+// false", which is the signature a dropping client would produce. That the head
+// still arrives in that run is also what proves the ssh binary really connected
+// and relayed through forwardSSH, rather than the case passing vacuously.
+func TestSSHForwardStockSSHClientReadsPastExitStatus(t *testing.T) {
+	const wantCode = 42
+
+	sshPath := requireStockSSHBinary(t)
+	addr, host := forwardTestStockClientHost(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, sshPath, stockSSHClientArgs(addr)...)
+	// Hold the client's stdin open so it does not send EOF and end the session
+	// before the host has finished its sequence. Nothing is ever written.
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = stdin.Close() }()
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	head := bytes.Repeat([]byte("h"), 4096)
+	tail := bytes.Repeat([]byte("t"), 4096)
+
+	sequence := make(chan error, 1)
+	go func() { sequence <- driveStockClientSession(host, head, tail, wantCode) }()
+
+	if err := forwardTestReceive(t, sequence); err != nil {
+		_ = cmd.Process.Kill()
+		t.Fatalf("host sequence failed: %v; ssh stderr: %s", err, stderr.String())
+	}
+
+	runErr := cmd.Wait()
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		t.Fatalf("stock ssh client timed out: %v; stderr: %s", ctxErr, stderr.String())
+	}
+
+	var exitErr *exec.ExitError
+	if !errors.As(runErr, &exitErr) || exitErr.ExitCode() != wantCode {
+		t.Fatalf("ssh exited with %v, want status %d; stderr: %s", runErr, wantCode, stderr.String())
+	}
+
+	got := stdout.Bytes()
+	if want := append(append([]byte{}, head...), tail...); !bytes.Equal(got, want) {
+		t.Fatalf("client output %d bytes, want %d (head %d + tail %d); tail present: %t",
+			len(got), len(want), len(head), len(tail),
+			bytes.Contains(got, tail))
+	}
+}
+
+// driveStockClientSession plays the host side: answer the session's setup
+// requests, send head, send exit-status, prove the client processed it, then
+// send tail and close.
+func driveStockClientSession(host sshPeer, head, tail []byte, code int) error {
+	newChannel, ok := <-host.channels
+	if !ok {
+		return errors.New("client opened no channel")
+	}
+	if newChannel.ChannelType() != "session" {
+		return fmt.Errorf("channel type %q, want session", newChannel.ChannelType())
+	}
+	channel, requests, err := newChannel.Accept()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = channel.Close() }()
+
+	// Answer setup requests until the client asks to run something. Replying
+	// to exec/shell is what makes ssh start relaying the session.
+	started := false
+	for !started {
+		request, ok := <-requests
+		if !ok {
+			return errors.New("client closed requests before starting a command")
+		}
+		switch request.Type {
+		case "exec", "shell", "subsystem":
+			started = true
+		}
+		if request.WantReply {
+			if err := request.Reply(true, nil); err != nil {
+				return err
+			}
+		}
+	}
+	go ssh.DiscardRequests(requests)
+
+	if _, err := channel.Write(head); err != nil {
+		return fmt.Errorf("writing head: %w", err)
+	}
+	status := struct{ Status uint32 }{uint32(code)}
+	if _, err := channel.SendRequest("exit-status", false, ssh.Marshal(&status)); err != nil {
+		return fmt.Errorf("sending exit-status: %w", err)
+	}
+
+	// The probe is the whole point. OpenSSH answers an unknown channel request
+	// with CHANNEL_FAILURE, and RFC 4254 §4 keeps channel requests in order, so
+	// receiving this reply proves the client already handled the exit-status
+	// ahead of it. ok is false by design; only the reply's arrival matters.
+	if _, err := channel.SendRequest("status-observed@upterm.test", true, nil); err != nil {
+		return fmt.Errorf("client did not answer the post-status probe: %w", err)
+	}
+
+	if _, err := channel.Write(tail); err != nil {
+		return fmt.Errorf("writing tail after exit-status: %w", err)
+	}
+	return channel.Close()
+}

--- a/server/sshforward_test.go
+++ b/server/sshforward_test.go
@@ -340,6 +340,14 @@ func (w *gatedSSHOutput) Write(p []byte) (int, error) {
 	return w.buffer.Write(p)
 }
 
+// sshChannelWindow mirrors x/crypto's unexported channelWindowSize
+// (64 * channelMaxPacket, channel.go:19-24 at v0.55.0). It is a calibration,
+// not an invariant: nothing enforces that it still matches upstream. If
+// x/crypto raises its window, flow-controlled-output silently stops being a
+// flow-control case and merely duplicates buffered-client-output. Re-derive it
+// when bumping x/crypto.
+const sshChannelWindow = 64 * (1 << 15)
+
 // Receiving exit-status is not the end of a Go session: Wait must also wait
 // for channel closure and its managed stdout/stderr copies. These cases test
 // those completion guarantees without assuming data/request wire order can be
@@ -352,10 +360,11 @@ func TestSSHForwardSessionWaitDrainsOutput(t *testing.T) {
 	}{
 		{"eof-before-status", 1024, true},
 		{"buffered-client-output", 1024, false},
-		// The combined 3 MiB exceeds the destination's 2 MiB window, but fits
-		// in the two hops' windows. The host can send status while forwarding
-		// is still blocked behind the guest's unread output.
-		{"flow-controlled-output", 1536 * 1024, false},
+		// Three halves of one window across the two streams: more than one
+		// hop's window, so forwarding blocks behind the guest's unread output,
+		// but less than the two hops' windows combined, so the host's writes
+		// still complete and it can send status while that block persists.
+		{"flow-controlled-output", 3 * sshChannelWindow / 4, false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			client, server, _, _ := forwardTestProxy(t)

--- a/server/sshforward_test.go
+++ b/server/sshforward_test.go
@@ -328,6 +328,143 @@ func TestSSHForwardHalfCloseStreamsAndExitStatus(t *testing.T) {
 	}
 }
 
+// gatedSSHOutput holds the session's managed output copy until the test allows
+// consumption. Read the buffer only after Session.Wait joins that copy.
+type gatedSSHOutput struct {
+	buffer  bytes.Buffer
+	release <-chan struct{}
+}
+
+func (w *gatedSSHOutput) Write(p []byte) (int, error) {
+	<-w.release
+	return w.buffer.Write(p)
+}
+
+// Receiving exit-status is not the end of a Go session: Wait must also wait
+// for channel closure and its managed stdout/stderr copies. These cases test
+// those completion guarantees without assuming data/request wire order can be
+// observed through the separate readers exposed by ssh.Channel.
+func TestSSHForwardSessionWaitDrainsOutput(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		bytesPerStream  int
+		eofBeforeStatus bool
+	}{
+		{"eof-before-status", 1024, true},
+		{"buffered-client-output", 1024, false},
+		// The combined 3 MiB exceeds the destination's 2 MiB window, but fits
+		// in the two hops' windows. The host can send status while forwarding
+		// is still blocked behind the guest's unread output.
+		{"flow-controlled-output", 1536 * 1024, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client, server, _, _ := forwardTestProxy(t)
+			sshClient := ssh.NewClient(client.conn, client.channels, client.requests)
+			type sessionResult struct {
+				session *ssh.Session
+				err     error
+			}
+			opened := make(chan sessionResult, 1)
+			go func() { session, err := sshClient.NewSession(); opened <- sessionResult{session, err} }()
+			incoming := forwardTestReceive(t, server.channels)
+			if incoming.ChannelType() != "session" {
+				t.Fatalf("channel type %q, want session", incoming.ChannelType())
+			}
+			host, requests, err := incoming.Accept()
+			if err != nil {
+				t.Fatal(err)
+			}
+			result := forwardTestReceive(t, opened)
+			if result.err != nil {
+				t.Fatal(result.err)
+			}
+			session := result.session
+			t.Cleanup(func() { _ = session.Close(); _ = host.Close() })
+			release := make(chan struct{})
+			allowOutput := sync.OnceFunc(func() { close(release) })
+			t.Cleanup(allowOutput)
+			stdout, stderr := &gatedSSHOutput{release: release}, &gatedSSHOutput{release: release}
+			session.Stdout, session.Stderr = stdout, stderr
+			if tc.eofBeforeStatus {
+				allowOutput()
+			}
+			started := make(chan error, 1)
+			go func() { started <- session.Start("test-output") }()
+			request := forwardTestReceive(t, requests)
+			if request.Type != "exec" || !request.WantReply {
+				t.Fatalf("unexpected start request: %+v", request)
+			}
+			if err := request.Reply(true, nil); err != nil {
+				t.Fatal(err)
+			}
+			go ssh.DiscardRequests(requests)
+			if err := forwardTestReceive(t, started); err != nil {
+				t.Fatal(err)
+			}
+			waited := make(chan error, 1)
+			go func() { waited <- session.Wait() }()
+			wantStdout := bytes.Repeat([]byte("o"), tc.bytesPerStream)
+			wantStderr := bytes.Repeat([]byte("e"), tc.bytesPerStream)
+			sent := make(chan error, 1)
+			go func() {
+				if _, err := host.Write(wantStdout); err != nil {
+					sent <- err
+					return
+				}
+				if _, err := host.Stderr().Write(wantStderr); err != nil {
+					sent <- err
+					return
+				}
+				if tc.eofBeforeStatus {
+					if err := host.CloseWrite(); err != nil {
+						sent <- err
+						return
+					}
+				}
+				if _, err := host.SendRequest("exit-status", false, ssh.Marshal(struct{ Status uint32 }{37})); err != nil {
+					sent <- err
+					return
+				}
+				// Session rejects unknown requests. Its reply proves it processed
+				// the preceding exit-status while the channel is still open.
+				ok, err := host.SendRequest("status-observed@upterm.test", true, nil)
+				if err == nil && ok {
+					err = errors.New("session accepted an unknown request")
+				}
+				sent <- err
+			}()
+			if err := forwardTestReceive(t, sent); err != nil {
+				t.Fatal(err)
+			}
+			if !tc.eofBeforeStatus {
+				if err := host.Close(); err != nil {
+					t.Fatal(err)
+				}
+			}
+			select {
+			case err := <-waited:
+				t.Fatalf("Wait returned before channel closure or output consumption: %v", err)
+			case <-time.After(100 * time.Millisecond):
+			}
+			allowOutput()
+			if tc.eofBeforeStatus {
+				if err := host.Close(); err != nil {
+					t.Fatal(err)
+				}
+			}
+			err = forwardTestReceive(t, waited)
+			var exit *ssh.ExitError
+			if !errors.As(err, &exit) || exit.ExitStatus() != 37 {
+				t.Fatalf("Wait returned %v, want exit status 37", err)
+			}
+			if !bytes.Equal(stdout.buffer.Bytes(), wantStdout) || !bytes.Equal(stderr.buffer.Bytes(), wantStderr) {
+				t.Fatalf("output truncated: stdout %d/%d bytes, stderr %d/%d bytes",
+					stdout.buffer.Len(), len(wantStdout), stderr.buffer.Len(), len(wantStderr))
+			}
+		})
+	}
+}
+
 func TestSSHForwardShutdownDrainsWorkers(t *testing.T) {
 	for _, shutdown := range []string{"cancel", "downstream", "upstream"} {
 		t.Run(shutdown, func(t *testing.T) {


### PR DESCRIPTION
No runtime behaviour changes here. This documents what `server/sshforward.go`'s
independent per-stream forwarding already guarantees, adds tests that pin
session completion (Go client) and trailing-output delivery (stock `ssh`
guest), and cites the flow-control constant a test depends on. The forwarding
code's behaviour is untouched.

Background: reviewing #526 ("Replace sshpiper with stock SSH and support go
install") raised the question of what moving from sshpiper's packet relay to
two independently-forwarded x/crypto channels gives up. That move introduced
an opportunity for the proxy to reorder observations across streams; nothing
indicated it had caused a failure. This is option C from that review: keep
independent forwarding, write the real guarantees into godoc where the next
person editing the forwarder will actually read them, and protect completion
with tests, rather than build an ordering mechanism nothing has shown is
needed.

**What's guaranteed**, now in godoc on `channelDirection` and
`copySSHChannel`:

1. Byte order within a stream — stdin, stdout and stderr are each a single
   `io.Copy` (`copySSHChannel`).
2. Request order within a direction — `sshForwarder.requests` dispatches from
   one serial sender, so replies return in send order (RFC 4254 §4).
3. Forwarded data precedes CLOSE, on the ordinary path — `channelDirection`
   waits on `requests` and `streams.Wait()` before calling
   `destination.Close()`; x/crypto refuses channel writes once CLOSE has gone
   out, so a peer reading until CHANNEL_CLOSE is not truncated there. The
   aborts are the exception: `abortPending` closes the destination from inside
   `requests`, before `streams.Wait()`, and cancellation, request-queue
   overflow and `sshForwardDrainTimeout` close both transports outright. Each
   of those can cut a `Write` that has not returned, and `copySSHChannel`
   discards the error. The godoc says so; an earlier draft of it claimed the
   guarantee unconditionally, which was wrong.
4. EOF precedes CLOSE, and half-close survives — `copySSHChannel` sends
   `CloseWrite` only after both data streams drain, so output produced after
   stdin EOF still reaches the guest.

A natural fifth property — the relative order of ordinary data, extended
data, and requests across a direction — is **not** guaranteed, and can't be
recovered at the current API boundary. x/crypto's mux read loop puts incoming
data into byte buffers and incoming requests onto `incomingRequests`, which is
a **buffered** Go channel (`chanSize = 16`). That buffer lets the read loop
run up to sixteen requests ahead, appending post-request bytes to the data
buffer before a consumer ever dequeues the request. Two different wire
histories — `data("a") -> window-change -> data("b")` and
`window-change -> data("ab")` — become indistinguishable downstream: same
reader contents, same request queue, no offset or sequence number tying them
together. Combining them into one queue in `channelDirection` would order
goroutine observations, not recover packet order. (If x/crypto ever makes
`incomingRequests` unbuffered, or exposes the read loop's own ordering, this
gets considerably cheaper.)

**Why the cheaper fix was rejected on cost, not feasibility.** The obvious
partial mitigation is a dispatch bias in `channelDirection`: service pending
requests ahead of pending data, so a resize is more likely to reach the host
before the stdin that follows it on the wire. This isn't proposed, because it
can't become a guarantee anyone could state or test: `host/internal/server.go`
applies window-change events and copies stdin to the pty in separate
`run.Group` actors, a scheduling boundary downstream of anything the proxy
does. Even a proxy that forwarded in perfect wire order could not promise the
host applies a resize before the stdin that follows it. Shifting a race that
stays untestable either way isn't worth the code. (Exact ordering would need
an observation point before x/crypto's demultiplexing — a different, more
expensive option, out of scope here.)

**The new stock-`ssh` test.**
`ftests/proxy_test.go:testProxyStockSSHClientTrailingOutput` joins with the
system `ssh` binary instead of a Go client. `README.md` documents
`ssh TOKEN@uptermd.upterm.dev` as how a guest joins, so OpenSSH is the
documented default guest, not an exotic one — and every other case in
`ftests/proxy_test.go` drives a Go `x/crypto` client. It forces a command that
writes 200,000 numbered lines and exits 42 with nothing in between, then
asserts all 200,000 lines and the exit code reach the guest — on both the
singleNode and multiNodes ssh-protocol topologies. They do.

Be precise about what that buys. It establishes that a real OpenSSH guest
receives every byte and the exit status through the relay under a high-volume
command that exits the instant it stops writing. It does **not** establish that
a client which stopped reading on `exit-status` would fail here. `exit-status`
is a channel request and can overtake buffered stdout inside the forwarder
(guarantee 3 orders data against CLOSE, not against a request) — but this test
never constructs that race. It does not force output to be undelivered at the
moment the status is processed, and the guest drains continuously into memory,
so the backlog at exit is small and scheduling-dependent. The discriminating
power against that specific defect is unmeasured.

Pinning it properly needs a host that withholds the trailing bytes until the
client has demonstrably processed the status — send output, send `exit-status`,
send an unknown channel request with `want_reply` and wait for the failure
reply, *then* send the remaining bytes and CLOSE. The `ftests` harness cannot
do that: its host is a real upterm host running a real shell, with no way to
inject a channel request mid-stream.

**The discriminating test.**
`server/sshforward_stockclient_test.go:TestSSHForwardStockSSHClientReadsPastExitStatus`
drives a real `ssh` binary through `forwardSSH` against a controlled host, and
constructs the race the functional case only approximates. The host writes a
head, sends `exit-status`, then sends an unknown channel request with
`want_reply` and waits for the answer — OpenSSH replies `CHANNEL_FAILURE` to
unknown requests, and RFC 4254 §4 keeps channel requests in order, so that reply
is proof the client already consumed the status. Only then does the host send
the tail. A client treating `exit-status` as end-of-session drops the tail; one
that quit outright never answers the probe and trips its timeout.

Its detection power is measured rather than asserted: withholding the tail write
makes it fail with `client output 4096 bytes, want 8192 ... tail present: false`
— the signature a dropping client produces. The head still arriving in that run
is what rules out a vacuous pass, since it proves the binary really connected
and relayed. OpenSSH passes.

`TestSSHForwardSessionWaitDrainsOutput` (`server/sshforward_test.go`) covers
the same completion property for the Go-client path (the upterm CLI's),
pinning that `Session.Wait()` joins channel closure and its managed
stdout/stderr copies rather than returning as soon as `exit-status` is
processed.

The same commit (`d975b7b`) also rewrites `testProxyWindowChange`'s comment in
`ftests/proxy_test.go`. Its retry loop is an eventual-application check, and
the rewritten comment names both boundaries the retry works around: the proxy
relays requests and data independently, and the host applies window events in
a separate `run.Group` actor from the one copying stdin to the pty, so a
following `stty` can still see the old size. The old comment named only the
missing reply.

**Test-window calibration, and its caveat.** The flow-controlled case in
`TestSSHForwardSessionWaitDrainsOutput` needs output that exceeds one hop's
SSH channel window while the guest isn't reading, so forwarding actually
blocks. `sshChannelWindow` in `server/sshforward_test.go` mirrors x/crypto's
own unexported `channelWindowSize` (`64 * channelMaxPacket` = 2 MiB). This is
a calibration against an implementation detail, not an invariant any API
enforces: if x/crypto changes that constant, the test keeps passing but
silently stops exercising flow control. The comment on `sshChannelWindow`
cites the source so the margin can be re-derived when x/crypto is bumped.

**Two pre-existing bugs this surfaced.** Neither is fixed here except where
noted; both are worth a follow-up:

- `ftests/ftests_test.go`'s subtest tree is flatter than it looks.
  `runTestCategory` and `runTestsForProtocol` call `suite.T().Run(...)`
  instead of the `t` their own closures receive, and nothing calls
  `suite.SetT(t)` inside those closures. testify freezes `suite.T()` at the
  top-level suite method, so every nested `Run` — for protocol (`ssh`/`ws`)
  and topology (`singleNode`/`multiNodes`) alike — registers as a direct
  child of that method, and Go's testing package dedups the resulting name
  collisions with `#01`. The actual tree under `TestProxy` is flat:
  `TestProxy/{ssh,singleNode,multiNodes,ws,singleNode#01,multiNodes#01}`, not
  the nested `TestProxy/ssh/singleNode/...` shape the code's structure
  suggests. Consequence: a nested `-run` filter such as
  `-run 'TestEmbedded/TestProxy/ssh/singleNode/testProxyStockSSHClientTrailingOutput'`
  does not error and does not report `[no tests to run]`. `TestEmbedded`
  matches at the top level, `TestProxy` matches, and `ssh` matches as a direct
  child with no children of its own, so the filter matches vacuously and the
  run passes:
  ```
  $ go test ./ftests/ -run 'TestEmbedded/TestProxy/ssh/singleNode/testProxyStockSSHClientTrailingOutput' -count=1
  ok  	github.com/owenthereal/upterm/ftests	0.830s
  ```
  Nothing here indicates `testProxyStockSSHClientTrailingOutput` never ran;
  `[no tests to run]` only appears when nothing matches at the top level.
  Deliberately not fixed here: fixing it renames every subtest path and
  deserves its own PR.
- The shared OpenSSH key fixtures were missing a trailing newline. x/crypto's
  key parser tolerates a key block with no trailing `\n`, but OpenSSH's own
  key loader rejects the file outright ("invalid format"), and this PR is the
  first to hand these fixtures to the real `ssh` binary rather than only to
  x/crypto clients. Fixed at the source, in `writeTempFile`
  (`ftests/ftests_test.go`), instead of worked around in the one test that
  newly needed it, since every caller of these fixtures benefits.

Verification: `go test $(go list ./... | grep -v /e2e) -timeout=180s
-count=1 -race` — every package `ok` or `no test files`. `ftests` alone is
race-clean at 56.7s.
