### PR TITLE
Pin that an abort cuts data still in flight

### DIFF
--- a/server/sshforward_test.go
+++ b/server/sshforward_test.go
@@ -1245,3 +1245,91 @@ func TestSSHForwardSimultaneousCloseWithPendingReplies(t *testing.T) {
 		_ = b.Close()
 	}
 }
+
+// TestSSHForwardAbortCutsBufferedData pins the documented exception to the
+// forwarder's data-before-CLOSE guarantee.
+//
+// channelDirection normally closes the destination only after both the request
+// tail and the data copy have drained, so a peer reading until CHANNEL_CLOSE
+// sees every forwarded byte. The abort path skips that: abortPending closes the
+// destination from inside requests, before streams.Wait(), to release a sender
+// whose source has gone away. Anything still queued behind a blocked Write is
+// lost, and copySSHChannel discards the resulting error.
+//
+// The other abort cases here (TestSSHForwardOriginCloseWithPendingReply,
+// TestSSHForwardSimultaneousCloseWithPendingReplies) have no data in flight, so
+// they never exercise that loss. This one stalls the destination so the copy is
+// blocked when the abort lands, and pins the truncation rather than leaving the
+// godoc's exception untested.
+func TestSSHForwardAbortCutsBufferedData(t *testing.T) {
+	// A stalled destination absorbs about two windows before anything blocks:
+	// one in b's own buffer, and one more in the forwarder's source-side buffer
+	// because reading from a replenishes a's credit. Two windows therefore sits
+	// exactly at capacity and the copy finishes given a moment — measured, not
+	// assumed. Four leaves the origin unable to finish, which is what makes
+	// "the copy was blocked when the abort landed" true rather than incidental.
+	const sent = 4 * sshChannelWindow
+
+	client, server, _, _ := forwardTestProxy(t)
+	a, ar, b, br := forwardTestChannel(t, client, server)
+	go ssh.DiscardRequests(ar)
+
+	// b never reads, so the forwarder's copy blocks once b's window fills and
+	// a's own window stops being replenished. Neither write can complete.
+	written := make(chan int, 1)
+	go func() {
+		n, _ := a.Write(bytes.Repeat([]byte("x"), sent))
+		written <- n
+	}()
+
+	// An unanswered request with a source that then disappears is what arms the
+	// abort. b receives it and deliberately never replies until cleanup.
+	pendingDone := make(chan bool, 1)
+	go func() { ok, _ := a.SendRequest("unanswered", true, nil); pendingDone <- ok }()
+	pending := forwardTestReceive(t, br)
+	defer func() { _ = pending.Reply(false, nil) }()
+
+	// Control: with the source still open, nothing closes the destination, and
+	// this outlasts sshRequestAbortGrace. Without it, the assertion below could
+	// be satisfied by any incidental close rather than by the abort.
+	select {
+	case _, ok := <-br:
+		if !ok {
+			t.Fatal("destination closed while the source was still open")
+		}
+		t.Fatal("unexpected second request")
+	case <-time.After(10 * sshRequestAbortGrace):
+	}
+
+	if err := a.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// b's request channel closing is the abort landing: the forwarder closed
+	// the destination without waiting for the blocked copy.
+	select {
+	case _, ok := <-br:
+		if ok {
+			t.Fatal("unexpected request after source close")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("abort did not close the destination while its data copy was blocked")
+	}
+
+	if forwardTestReceive(t, pendingDone) {
+		t.Fatal("aborted request succeeded")
+	}
+
+	// Whatever reached b's buffer before the abort is still readable; the rest
+	// is gone. Bounding it below `sent` is the truncation this documents.
+	got, err := io.ReadAll(b)
+	if err != nil {
+		t.Fatalf("draining destination after abort: %v", err)
+	}
+	if len(got) >= sent {
+		t.Fatalf("destination received %d of %d bytes; expected the abort to cut the copy", len(got), sent)
+	}
+	if n := forwardTestReceive(t, written); n >= sent {
+		t.Fatalf("origin wrote %d of %d bytes; the copy was never actually blocked", n, sent)
+	}
+}

--- a/server/sshforward_test.go
+++ b/server/sshforward_test.go
@@ -1268,6 +1268,11 @@ func TestSSHForwardSimultaneousCloseWithPendingReplies(t *testing.T) {
 // and the missing window is the cut. Every assertion here is an upper bound, so
 // the gate that waits for two windows to be accepted is what keeps the case
 // from passing on a run where nothing moved — measured, not assumed.
+//
+// Every wait here is sized against forwardTestPair's absolute 10s transport
+// deadline: 3s to fill the pipeline, 1s of control, 3s for the abort to land.
+// Past that deadline the transports are gone and no bound can be informative,
+// so the waits stay inside it rather than outlasting it.
 func TestSSHForwardAbortCutsBufferedData(t *testing.T) {
 	// A stalled destination absorbs about two windows before anything blocks:
 	// one in b's own buffer, and one more in the forwarder's source-side buffer
@@ -1286,7 +1291,9 @@ func TestSSHForwardAbortCutsBufferedData(t *testing.T) {
 	// Writing in chunks publishes progress, which the gate below needs.
 	var accepted atomic.Int64
 	written := make(chan int, 1)
+	writerDone := make(chan struct{})
 	go func() {
+		defer close(writerDone)
 		chunk := bytes.Repeat([]byte("x"), 64<<10)
 		total := 0
 		for total < sent {
@@ -1312,12 +1319,23 @@ func TestSSHForwardAbortCutsBufferedData(t *testing.T) {
 	// makes Write return 0, ReadAll returns 0, and 0 is under every ceiling.
 	// Waiting for two windows to be accepted means the forwarder has drained a
 	// window out of a and pushed it at b, so there is real data in the pipeline
-	// to cut. A loaded scheduler delays this rather than defeating it.
-	deadline := time.After(30 * time.Second)
+	// to cut.
+	//
+	// The budget is not ours to choose freely: forwardTestPair puts an absolute
+	// 10s deadline on both transports, so a wait longer than that cannot make
+	// progress, it can only turn a dead transport into a late and misleading
+	// "nothing to cut". Stay well inside it, and watch the writer as well as the
+	// clock — if it stops early the transport or channel ended, which is a
+	// different failure and deserves to say so.
+	gate := time.After(3 * time.Second)
 	for accepted.Load() < 2*sshChannelWindow {
 		select {
-		case <-deadline:
-			t.Fatalf("only %d bytes entered the forwarding path; nothing to cut", accepted.Load())
+		case <-writerDone:
+			t.Fatalf("origin stopped writing at %d of the %d bytes the pipeline needs; "+
+				"the channel or transport ended before the abort was armed", accepted.Load(), 2*sshChannelWindow)
+		case <-gate:
+			t.Fatalf("only %d of the %d bytes needed entered the forwarding path within the transport budget",
+				accepted.Load(), 2*sshChannelWindow)
 		case <-time.After(time.Millisecond):
 		}
 	}
@@ -1349,7 +1367,7 @@ func TestSSHForwardAbortCutsBufferedData(t *testing.T) {
 		if ok {
 			t.Fatal("unexpected request after source close")
 		}
-	case <-time.After(5 * time.Second):
+	case <-time.After(3 * time.Second):
 		t.Fatal("abort did not close the destination while its data copy was blocked")
 	}
 

--- a/server/sshforward_test.go
+++ b/server/sshforward_test.go
@@ -12,6 +12,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -1261,6 +1262,12 @@ func TestSSHForwardSimultaneousCloseWithPendingReplies(t *testing.T) {
 // they never exercise that loss. This one stalls the destination so the copy is
 // blocked when the abort lands, and pins the truncation rather than leaving the
 // godoc's exception untested.
+//
+// The figures are stable because the pipeline saturates: the origin gets
+// exactly two windows accepted, the destination ends up holding exactly one,
+// and the missing window is the cut. Every assertion here is an upper bound, so
+// the gate that waits for two windows to be accepted is what keeps the case
+// from passing on a run where nothing moved — measured, not assumed.
 func TestSSHForwardAbortCutsBufferedData(t *testing.T) {
 	// A stalled destination absorbs about two windows before anything blocks:
 	// one in b's own buffer, and one more in the forwarder's source-side buffer
@@ -1276,10 +1283,21 @@ func TestSSHForwardAbortCutsBufferedData(t *testing.T) {
 
 	// b never reads, so the forwarder's copy blocks once b's window fills and
 	// a's own window stops being replenished. Neither write can complete.
+	// Writing in chunks publishes progress, which the gate below needs.
+	var accepted atomic.Int64
 	written := make(chan int, 1)
 	go func() {
-		n, _ := a.Write(bytes.Repeat([]byte("x"), sent))
-		written <- n
+		chunk := bytes.Repeat([]byte("x"), 64<<10)
+		total := 0
+		for total < sent {
+			n, err := a.Write(chunk)
+			total += n
+			accepted.Add(int64(n))
+			if err != nil {
+				break
+			}
+		}
+		written <- total
 	}()
 
 	// An unanswered request with a source that then disappears is what arms the
@@ -1289,9 +1307,24 @@ func TestSSHForwardAbortCutsBufferedData(t *testing.T) {
 	pending := forwardTestReceive(t, br)
 	defer func() { _ = pending.Reply(false, nil) }()
 
+	// Lower bound, and the load-bearing one. Every assertion below is an upper
+	// bound, so without this the case passes when nothing ever moved: a.Close()
+	// makes Write return 0, ReadAll returns 0, and 0 is under every ceiling.
+	// Waiting for two windows to be accepted means the forwarder has drained a
+	// window out of a and pushed it at b, so there is real data in the pipeline
+	// to cut. A loaded scheduler delays this rather than defeating it.
+	deadline := time.After(30 * time.Second)
+	for accepted.Load() < 2*sshChannelWindow {
+		select {
+		case <-deadline:
+			t.Fatalf("only %d bytes entered the forwarding path; nothing to cut", accepted.Load())
+		case <-time.After(time.Millisecond):
+		}
+	}
+
 	// Control: with the source still open, nothing closes the destination, and
-	// this outlasts sshRequestAbortGrace. Without it, the assertion below could
-	// be satisfied by any incidental close rather than by the abort.
+	// this outlasts sshRequestAbortGrace. Without it, the close below could be
+	// any incidental close rather than the abort.
 	select {
 	case _, ok := <-br:
 		if !ok {
@@ -1300,6 +1333,10 @@ func TestSSHForwardAbortCutsBufferedData(t *testing.T) {
 		t.Fatal("unexpected second request")
 	case <-time.After(10 * sshRequestAbortGrace):
 	}
+
+	// What the origin had successfully written by the time the abort was armed.
+	// The destination must end up with strictly less than this.
+	inFlight := accepted.Load()
 
 	if err := a.Close(); err != nil {
 		t.Fatal(err)
@@ -1321,15 +1358,18 @@ func TestSSHForwardAbortCutsBufferedData(t *testing.T) {
 	}
 
 	// Whatever reached b's buffer before the abort is still readable; the rest
-	// is gone. Bounding it below `sent` is the truncation this documents.
+	// is gone. Comparing against what the origin actually wrote — not against
+	// `sent` — is what makes this a statement about cut data rather than about
+	// an unfinished write.
 	got, err := io.ReadAll(b)
 	if err != nil {
 		t.Fatalf("draining destination after abort: %v", err)
 	}
-	if len(got) >= sent {
-		t.Fatalf("destination received %d of %d bytes; expected the abort to cut the copy", len(got), sent)
+	if int64(len(got)) >= inFlight {
+		t.Fatalf("destination received %d bytes of the %d the origin wrote; expected the abort to cut the copy",
+			len(got), inFlight)
 	}
 	if n := forwardTestReceive(t, written); n >= sent {
-		t.Fatalf("origin wrote %d of %d bytes; the copy was never actually blocked", n, sent)
+		t.Fatalf("origin wrote all %d bytes; the copy was never actually blocked", sent)
 	}
 }


### PR DESCRIPTION
server: pin that an abort cuts data still in flight

channelDirection normally closes the destination only after the request tail
and the data copy have both drained, so a peer reading until CHANNEL_CLOSE sees
every forwarded byte. The abort path skips that: abortPending closes the
destination from inside requests, before streams.Wait(), to release a sender
whose source has gone away. Whatever is queued behind a blocked Write is lost,
and copySSHChannel discards the error.

#530 documented that exception but left it untested. The existing abort cases
have no data in flight, so they never exercise the loss. Stall the destination
so the copy is blocked when the abort lands, then assert the truncation.

Two things are measured rather than assumed. A stalled destination absorbs about
two channel windows before anything blocks -- one in the destination's buffer,
one more in the forwarder's source-side buffer, because reading from the source
replenishes its credit -- so a two-window payload sits at capacity and completes
given a moment. The payload is four windows for that reason. And the case holds
a control interval longer than sshRequestAbortGrace with the source still open,
so the later close is attributable to the abort rather than to any incidental
close; that control is what showed the two-window payload was passing on timing.

