### PR TITLE
Fix head-of-line blocking in the output fan-out (#524)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,9 +40,13 @@ docker_build:
 	docker buildx build -t $(REPO):$(TAG) -f Dockerfile.uptermd $(DOCKER_BUILD_FLAGS) .
 
 GO_TEST_FLAGS ?= ""
+# The bound is a guard against a hung test, not a performance budget. ftests is
+# what sets it: on the Consul job it runs both suites in one binary and had
+# grown to 126s of the old 180s before this timeout was last touched, leaving
+# less headroom than runner-to-runner variance.
 .PHONY: test
 test:
-	go test $$(go list ./... | grep -v /e2e) -timeout=180s -coverprofile=c.out -covermode=atomic -count=1 -race -v $(GO_TEST_FLAGS)
+	go test $$(go list ./... | grep -v /e2e) -timeout=300s -coverprofile=c.out -covermode=atomic -count=1 -race -v $(GO_TEST_FLAGS)
 
 # E2E tests require tmux and UPTERM_E2E_SERVER env var
 # Example: UPTERM_E2E_SERVER=ssh://uptermd.upterm.dev:22 make test-e2e

--- a/ftests/ftests_test.go
+++ b/ftests/ftests_test.go
@@ -120,6 +120,8 @@ var ConnectionTestCases = []FtestCase{
 	testClientAttachReadOnly,
 	testClientLocalPortForwardDisabled,
 	testClientLocalPortForward,
+	testClientSlowGuestDropped,
+	testHostExitsWhileGuestHoldsConnection,
 }
 
 // CallbackTestCases contains all callback/event-related test functions
@@ -459,10 +461,16 @@ type Host struct {
 	SFTPDisabled             bool // Disable SFTP subsystem
 	inputCh                  chan string
 	outputCh                 chan string
+	done                     chan struct{}
 	ctx                      context.Context
 	cancel                   func()
 	wg                       sync.WaitGroup
 }
+
+// Done closes when Host.Run has returned. Host.Close only cancels and then
+// times out, so it cannot distinguish a clean exit from a hang — which is
+// exactly what a test of shutdown needs to know.
+func (c *Host) Done() <-chan struct{} { return c.done }
 
 func (c *Host) Close() {
 	// Cancel context to signal goroutines to stop
@@ -493,6 +501,7 @@ func (c *Host) init() {
 	c.ctx, c.cancel = context.WithCancel(context.Background())
 	c.inputCh = make(chan string)
 	c.outputCh = make(chan string)
+	c.done = make(chan struct{})
 }
 
 func (c *Host) Share(url string) error {
@@ -558,6 +567,7 @@ func (c *Host) Share(url string) error {
 		// output that may never come.
 		_ = stdoutw.Close()
 		_ = stdinr.Close()
+		close(c.done)
 		if err != nil {
 			testLogger.Error("error running host", "error", err)
 			errCh <- err
@@ -628,14 +638,18 @@ func (c *Host) InputOutput() (chan string, chan string) {
 
 type Client struct {
 	PrivateKeys []string
-	sshClient   *ssh.Client
-	session     *ssh.Session
-	sshStdin    io.WriteCloser
-	sshStdout   io.Reader
-	inputCh     chan string
-	outputCh    chan string
-	cancel      func()
-	wg          sync.WaitGroup
+	// NoDrainStdout leaves the session's stdout unread, modelling a guest that
+	// has stopped draining its SSH channel. Its window fills, and the host's
+	// write to it blocks.
+	NoDrainStdout bool
+	sshClient     *ssh.Client
+	session       *ssh.Session
+	sshStdin      io.WriteCloser
+	sshStdout     io.Reader
+	inputCh       chan string
+	outputCh      chan string
+	cancel        func()
+	wg            sync.WaitGroup
 }
 
 func (c *Client) init() {
@@ -645,6 +659,13 @@ func (c *Client) init() {
 
 func (c *Client) InputOutput() (chan string, chan string) {
 	return c.inputCh, c.outputCh
+}
+
+// WaitSession returns when the session's channel closes. It does not read
+// stdout, so a client left deliberately undrained can still observe that the
+// host disconnected it.
+func (c *Client) WaitSession() error {
+	return c.session.Wait()
 }
 
 // SFTP returns an SFTP client using the existing SSH connection.
@@ -748,7 +769,7 @@ func (c *Client) JoinWithContext(ctx context.Context, session *api.GetSessionRes
 	var g run.Group
 	ctx, cancel := context.WithCancel(ctx)
 	c.cancel = cancel // Store cancel function for cleanup
-	{
+	if !c.NoDrainStdout {
 		// output
 		g.Add(func() error {
 			w := writeFunc(func(pp []byte) (int, error) {

--- a/ftests/slowguest_test.go
+++ b/ftests/slowguest_test.go
@@ -201,7 +201,8 @@ func testClientSlowGuestDropped(t *testing.T, hostURL, hostNodeAddr, clientJoinU
 	closed := make(chan error, 1)
 	go func() { closed <- stalled.WaitSession() }()
 
-	expiry := time.Now().Add(burstLoopBudget(t))
+	budget := burstLoopBudget(t)
+	expiry := time.Now().Add(budget)
 
 	// The burst is produced a chunk at a time, and the next chunk is not asked
 	// for until the guest that is still reading has seen the last one. Blasting
@@ -217,7 +218,7 @@ func testClientSlowGuestDropped(t *testing.T, hostURL, hostNodeAddr, clientJoinU
 	for chunk := 0; chunk < burstChunks && dropped == nil; chunk++ {
 		if time.Now().After(expiry) {
 			t.Fatalf("the stalled guest was not dropped within %s, after %d of %d bytes of output; raise burstBudget, and burstChunks with it if the whole ceiling was spent",
-				burstBudget, produced, burstChunks*burstChunkBytes)
+				budget, produced, burstChunks*burstChunkBytes)
 		}
 
 		hostInput <- "" // go-ahead for one chunk

--- a/ftests/slowguest_test.go
+++ b/ftests/slowguest_test.go
@@ -160,6 +160,22 @@ func TestBurstHelperChunks(t *testing.T) {
 // the forwarder's watchdog turns that into a closed channel the guest can
 // observe without ever resuming reads.
 func testClientSlowGuestDropped(t *testing.T, hostURL, hostNodeAddr, clientJoinURL string) {
+	// The suite runs every connection case over both protocols, and this one is
+	// far and away the most expensive: the stalled guest cannot observe its own
+	// disconnect until sshForwardChannelDrainTimeout and the abort grace have
+	// both elapsed, so it costs seconds where its neighbours cost about one,
+	// and it sets the critical path of whichever topology group it runs in.
+	//
+	// Running it on ssh only costs nothing real. What stalls the guest is SSH
+	// channel windowing, which is identical on both: the WebSocket protocol
+	// changes how bytes reach uptermd, not how a channel's window is accounted.
+	// The topology axis is the one that matters here and is kept — a
+	// node-to-node hop puts a second forwarder in the path, with its own abort
+	// scope to get right.
+	if !strings.HasPrefix(hostURL, "ssh://") {
+		t.Skip("covered on ssh; the stall is SSH channel windowing, not transport-specific")
+	}
+
 	left := make(chan *api.Client, 4)
 
 	adminSocketFile := setupAdminSocket(t)

--- a/ftests/slowguest_test.go
+++ b/ftests/slowguest_test.go
@@ -1,0 +1,383 @@
+package ftests
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/owenthereal/upterm/host/api"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// burstChunkBytes is how much output the host produces per go-ahead. It is
+	// the bound on how far the guest that keeps reading may fall behind, because
+	// the test never asks for the next chunk until that guest has seen the last
+	// one, so it has to stay well under the 1 MiB host-side cap.
+	burstChunkBytes = 256 << 10
+
+	// burstChunks caps the burst at burstChunks * burstChunkBytes = 16 MiB. That
+	// has to exceed what the path already buffers before the host's write to a
+	// stalled guest blocks: up to 2 MiB of SSH window on each leg between host
+	// and guest, plus TCP socket buffers, plus the 1 MiB host-side cap — roughly
+	// 5.5 MiB for one node and more for two, and platform-dependent because
+	// Windows autotunes its socket buffers. The loop stops as soon as the drop
+	// lands, so the margin costs nothing when it lands early; if it never lands,
+	// this is the knob to raise.
+	burstChunks = 64
+
+	// burstLineWidth matches the guests' 80-column pty, so the burst is not
+	// re-wrapped on the way through and a marker stays on one line.
+	burstLineWidth = 80
+
+	burstChunkMarker = "BURST-CHUNK-"
+
+	// burstChunkTimeout bounds the wait for one 256 KiB chunk to cross the whole
+	// path. Measured on the happy path a chunk takes tens of milliseconds, so
+	// this is about whether the fan-out is stuck, not about how loaded the
+	// machine is. It is deliberately shorter than burstBudget, so a fan-out that
+	// has genuinely wedged is reported against the chunk it wedged on rather
+	// than against the loop as a whole.
+	burstChunkTimeout = 10 * time.Second
+
+	// burstBudget bounds the paced loop in wall-clock time, which burstChunks
+	// alone does not: a platform whose socket buffers push the drop late can
+	// legitimately produce all 64 chunks, once per topology, inside a binary
+	// that make test gives 180 s in total.
+	//
+	// 25 s is a little over twice the slowest healthy run measured here
+	// (ssh/multiNodes, 28 chunks, 11.8 s under -race), and four of those on top
+	// of the ~56 s the rest of the suite costs still fits. The loop clamps it
+	// further against the binary's own deadline, because a case that fails
+	// naming its knob is worth more than a timeout panic that takes every other
+	// ftest down with it.
+	burstBudget = 25 * time.Second
+
+	// guestDropTimeout is how long the dropped guest has to observe its own
+	// disconnect. It budgets a different mechanism from the two above: the drop
+	// reaches the guest through uptermd's watchdog, which waits
+	// sshForwardChannelDrainTimeout before closing the stalled channel and
+	// sshForwardChannelAbortGrace again before escalating — several seconds of
+	// deliberate delay that no amount of throughput removes.
+	guestDropTimeout = 30 * time.Second
+)
+
+// TestBurstHelper is not a test. It is the host command for
+// testClientSlowGuestDropped: re-executing this binary generates the burst
+// without a shell, so the case runs identically on macOS, Linux and Windows.
+//
+// It skips unless invoked with a chunk count, so an ordinary suite run walks
+// past it.
+func TestBurstHelper(t *testing.T) {
+	chunks, ok := burstHelperChunks(flag.Args())
+	if !ok {
+		t.Skip("helper process, not run directly")
+	}
+
+	in := bufio.NewReader(os.Stdin)
+	line := strings.Repeat("x", burstLineWidth-1) + "\n"
+	for i := 0; i < chunks; i++ {
+		// One line of input buys one chunk. The producer never runs ahead of
+		// the guest that is still reading, so that guest cannot be dropped for
+		// falling behind and only the guest that has stopped reading does.
+		if _, err := in.ReadString('\n'); err != nil {
+			return
+		}
+		for written := 0; written < burstChunkBytes; written += len(line) {
+			if _, err := os.Stdout.WriteString(line); err != nil {
+				return
+			}
+		}
+		if _, err := fmt.Fprintf(os.Stdout, "%s%03d\n", burstChunkMarker, i); err != nil {
+			return
+		}
+	}
+
+	// Hold the session open past the burst, so the drop can be observed while
+	// the host is still running.
+	_, _ = in.ReadString('\n')
+}
+
+// burstHelperChunks reads the chunk count out of the positional arguments and
+// reports whether this process was invoked as the helper at all.
+//
+// "There are no positionals" is not a reliable test of that, and assuming it
+// broke make test on this branch. The Makefile has GO_TEST_FLAGS ?= "" and
+// interpolates it unquoted, so an ordinary `make test` hands the binary a
+// literal empty string as a positional argument and flag.Args() has length one.
+// Plain `go test ./ftests/...` does not, which is why every check that did not
+// run the real command missed it.
+//
+// So the test is whether the argument is a usable count, and anything else
+// declines rather than fails: a helper that cannot tell it was invoked as a
+// helper is looking at someone else's command line, not at a broken one. Zero
+// is a real count — testHostExitsWhileGuestHoldsConnection passes it to get a
+// command that exits as soon as it is released.
+func burstHelperChunks(args []string) (int, bool) {
+	if len(args) != 1 {
+		return 0, false
+	}
+	chunks, err := strconv.Atoi(args[0])
+	if err != nil || chunks < 0 {
+		return 0, false
+	}
+	return chunks, true
+}
+
+// The empty-string case below is the one that matters: it is what `make test`
+// actually passes, and TestBurstHelper's own SKIP is invisible to a suite run
+// that does not reproduce it.
+func TestBurstHelperChunks(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+		want int
+		ok   bool
+	}{
+		{name: "no positionals", args: nil},
+		{name: "make test's empty GO_TEST_FLAGS", args: []string{""}},
+		{name: "not a number", args: []string{"-race"}},
+		{name: "negative", args: []string{"-1"}},
+		{name: "more than one positional", args: []string{"4", "8"}},
+		{name: "zero chunks", args: []string{"0"}, want: 0, ok: true},
+		{name: "a real count", args: []string{"64"}, want: 64, ok: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			chunks, ok := burstHelperChunks(tc.args)
+			require.Equal(t, tc.ok, ok, "helper invocation should be recognised as %v", tc.ok)
+			require.Equal(t, tc.want, chunks)
+		})
+	}
+}
+
+// One guest that has stopped reading must not stall the host or another guest,
+// and must itself be disconnected — all the way through: the host drops it, and
+// the forwarder's watchdog turns that into a closed channel the guest can
+// observe without ever resuming reads.
+func testClientSlowGuestDropped(t *testing.T, hostURL, hostNodeAddr, clientJoinURL string) {
+	left := make(chan *api.Client, 4)
+
+	adminSocketFile := setupAdminSocket(t)
+
+	h := &Host{
+		Command:                  []string{os.Args[0], "-test.run=^TestBurstHelper$", strconv.Itoa(burstChunks)},
+		PrivateKeys:              []string{HostPrivateKey},
+		AdminSocketFile:          adminSocketFile,
+		PermittedClientPublicKey: ClientPublicKeyContent,
+		ClientLeftCallback:       func(c *api.Client) { left <- c },
+	}
+	require.NoError(t, h.Share(hostURL))
+	defer h.Close()
+
+	session := getAndVerifySession(t, adminSocketFile, hostURL, hostNodeAddr)
+
+	stalled := &Client{PrivateKeys: []string{ClientPrivateKey}, NoDrainStdout: true}
+	require.NoError(t, stalled.Join(session, clientJoinURL))
+	defer stalled.Close()
+
+	healthy := &Client{PrivateKeys: []string{ClientPrivateKey}}
+	require.NoError(t, healthy.Join(session, clientJoinURL))
+	defer healthy.Close()
+
+	// Both readers must run *concurrently*, and must be started before the
+	// first go-ahead. Client.JoinWithContext pumps output into an unbuffered
+	// channel, so a guest whose channel nobody is reading stops reading its SSH
+	// channel — draining the host to completion first would turn the "healthy"
+	// guest into a second stalled one and it would be dropped too. This is the
+	// same hazard ftests/host_test.go:106 already documents.
+	hostInput, hostOutput := h.InputOutput()
+	_, healthyOutput := healthy.InputOutput()
+	hostMarkers := watchMarkers(hostOutput)
+	healthyMarkers := watchMarkers(healthyOutput)
+
+	// Observe the stalled guest's own channel without ever reading its stdout.
+	// Started before the burst because the forwarder's watchdog takes seconds to
+	// escalate, and there is no reason to spend them serially.
+	closed := make(chan error, 1)
+	go func() { closed <- stalled.WaitSession() }()
+
+	expiry := time.Now().Add(burstLoopBudget(t))
+
+	// The burst is produced a chunk at a time, and the next chunk is not asked
+	// for until the guest that is still reading has seen the last one. Blasting
+	// instead would prove nothing: the host reads its own pty several times
+	// faster than a guest can drain an SSH channel under -race, so an
+	// unthrottled burst overflows every guest's 1 MiB cap, the healthy one
+	// included, and the case could not tell "stopped reading" from "reading".
+	// Pacing on the guest rather than on a timer is what keeps that true on a
+	// machine of any speed. What that costs in wall clock is bounded by expiry
+	// rather than by burstChunks, which is a ceiling on volume, not on time.
+	var dropped *api.Client
+	var produced int
+	for chunk := 0; chunk < burstChunks && dropped == nil; chunk++ {
+		if time.Now().After(expiry) {
+			t.Fatalf("the stalled guest was not dropped within %s, after %d of %d bytes of output; raise burstBudget, and burstChunks with it if the whole ceiling was spent",
+				burstBudget, produced, burstChunks*burstChunkBytes)
+		}
+
+		hostInput <- "" // go-ahead for one chunk
+		produced += burstChunkBytes
+
+		// The host's own terminal keeps up. This is the head-of-line assertion
+		// for the host: the fan-out writes to it synchronously, so before
+		// per-guest buffering the stalled guest froze the host's own screen.
+		awaitBurstChunk(t, hostMarkers, chunk, "the host's terminal")
+
+		// So does the guest that kept reading — the head-of-line assertion for
+		// the other guests.
+		awaitBurstChunk(t, healthyMarkers, chunk, "a healthy guest")
+
+		// Which guest left is established by elimination, not by matching the
+		// event: both guests authenticate with the same key, so there is nothing
+		// cheap to match on, and the healthy one has just delivered this chunk's
+		// marker. If it were ever the healthy guest that had been dropped, the
+		// WaitSession below would not return and the case would fail there — a
+		// true failure, but reported one assertion after its cause.
+		select {
+		case c := <-left:
+			dropped = c
+		default:
+		}
+	}
+	if dropped == nil {
+		// The poll above is non-blocking so the loop can stop as soon as a drop
+		// is visible. A drop landing during the final chunk has not necessarily
+		// been delivered by the time the loop runs out of chunks, and reporting
+		// that as "never dropped" would be wrong.
+		select {
+		case c := <-left:
+			dropped = c
+		case <-time.After(callbackTimeout):
+		}
+	}
+	require.NotNil(t, dropped, "the stalled guest was never dropped within %d bytes of output; raise burstChunks", burstChunks*burstChunkBytes)
+	// How much of the budget the drop actually needed. It varies with the number
+	// of hops and with the platform's socket buffers, so it is the number to
+	// look at before changing burstChunks.
+	t.Logf("stalled guest dropped after %d of %d bytes of output", produced, burstChunks*burstChunkBytes)
+
+	// The drop has to reach the guest. The host-side callback alone would pass
+	// even if the guest were left stranded on uptermd, which is what the
+	// forwarder's watchdog prevents.
+	select {
+	case <-closed:
+	case <-time.After(guestDropTimeout):
+		t.Fatal("the stalled guest was never disconnected")
+	}
+}
+
+// burstLoopBudget is how long the paced loop may run.
+//
+// burstBudget is the figure to tune, but it is clamped against what is left of
+// the binary's own -timeout, which is what the loop is really competing for:
+// four topologies run this case, and make test gives the whole ftests binary
+// 180 s. Overrunning that is a panic that takes every other ftest with it,
+// whereas overrunning burstBudget is one failure naming one knob.
+func burstLoopBudget(t *testing.T) time.Duration {
+	budget := burstBudget
+	if deadline, ok := t.Deadline(); ok {
+		if half := time.Until(deadline) / 2; half > 0 && half < budget {
+			budget = half
+		}
+	}
+	return budget
+}
+
+// A guest that keeps its SSH connection open after the host's command exits
+// must not hold the host open. charm.land/ssh's Shutdown waits on its
+// connection WaitGroup until the context it is handed is done, so this hangs
+// if that context is still live — and the deferred ReverseTunnel.Close never
+// runs, wedging the process rather than any one session.
+//
+// The exit must be command-led. Cancelling the host instead would make the
+// context done for the wrong reason and the test would pass either way.
+func testHostExitsWhileGuestHoldsConnection(t *testing.T, hostURL, hostNodeAddr, clientJoinURL string) {
+	adminSocketFile := setupAdminSocket(t)
+
+	h := &Host{
+		Command:                  []string{os.Args[0], "-test.run=^TestBurstHelper$", "0"},
+		PrivateKeys:              []string{HostPrivateKey},
+		AdminSocketFile:          adminSocketFile,
+		PermittedClientPublicKey: ClientPublicKeyContent,
+	}
+	require.NoError(t, h.Share(hostURL))
+	defer h.Close()
+
+	session := getAndVerifySession(t, adminSocketFile, hostURL, hostNodeAddr)
+
+	c := &Client{PrivateKeys: []string{ClientPrivateKey}}
+	require.NoError(t, c.Join(session, clientJoinURL))
+	_, guestOutput := c.InputOutput()
+	go func() {
+		for range guestOutput { //nolint:revive // drained, not inspected
+		}
+	}()
+	// Deliberately never closed: the guest keeps its SSH connection while the
+	// host's command exits underneath it.
+
+	hostInput, _ := h.InputOutput()
+	hostInput <- "" // zero chunks, so this one line lets the helper exit on its own
+
+	select {
+	case <-h.Done():
+	case <-time.After(30 * time.Second):
+		t.Fatal("the host did not exit while a guest held its connection open")
+	}
+}
+
+// awaitBurstChunk waits for the marker that closes one chunk of the burst.
+//
+// Markers carry their index and are matched on it rather than counted, so a
+// terminal that repeats a line — ConPTY re-renders, readline redraws — cannot
+// walk the loop one chunk ahead of what the reader has actually received.
+func awaitBurstChunk(t *testing.T, markers <-chan string, chunk int, who string) {
+	t.Helper()
+	want := fmt.Sprintf("%s%03d", burstChunkMarker, chunk)
+	deadline := time.After(burstChunkTimeout)
+	for {
+		select {
+		case got := <-markers:
+			if strings.Contains(got, want) {
+				return
+			}
+		case <-deadline:
+			t.Fatalf("%s did not receive chunk %d of the burst within %s", who, chunk, burstChunkTimeout)
+		}
+	}
+}
+
+// watchMarkers starts draining ch immediately and reports every line carrying a
+// burst marker.
+//
+// It must start draining at once: these output channels are unbuffered, so a
+// channel nobody reads stops its client reading its SSH channel, which is
+// exactly the state this case reserves for the one guest that is meant to be in
+// it. And it cannot test each chunk with strings.Contains — a marker split
+// across two chunks would be missed — so it scans the stream, using the suite's
+// existing scanner helper, which pipes the channel into a bufio.Scanner for
+// exactly this reason.
+func watchMarkers(ch chan string) <-chan string {
+	markers := make(chan string, 2*burstChunks)
+	go func() {
+		s := scanner(ch)
+		for s.Scan() {
+			if !strings.Contains(s.Text(), burstChunkMarker) {
+				continue
+			}
+			select {
+			case markers <- s.Text():
+			default: // never block the drain on a test that stopped reading
+			}
+		}
+		// Keep draining: stopping here would stall the client whose output
+		// this is.
+		for range ch { //nolint:revive // drained, not inspected
+		}
+	}()
+	return markers
+}

--- a/host/internal/command.go
+++ b/host/internal/command.go
@@ -21,6 +21,12 @@ const (
 	outputIdleTimeout = 100 * time.Millisecond
 	// outputDrainTimeout bounds the total time spent draining after exit.
 	outputDrainTimeout = time.Second
+	// guestFlushTimeout bounds how long the fan-out waits for asynchronous
+	// guests to receive what it has already accepted, once the producer has
+	// stopped. A guest still behind when it expires loses the remainder; it is
+	// deliberately not dropped for that, because the session is ending and a
+	// slow last second is not an overflow.
+	guestFlushTimeout = time.Second
 )
 
 // activityWriter records when it last wrote, so a drain can stop once output
@@ -169,6 +175,19 @@ func (c *command) Run() error {
 		output := &activityWriter{Writer: c.writers}
 		done := make(chan struct{})
 		g.Add(func() error {
+			// Runs last, by LIFO. The copy has returned, so the producer has
+			// provably stopped and nothing further can enter the fan-out: this
+			// is the only point where a flush is a barrier rather than a guess.
+			// Putting it in the interrupt instead would race the producer, and
+			// waiting there for the copy would not even be bounded — cancelling
+			// the reader cannot release a copy blocked in the synchronous write
+			// to c.stdout, and run.Group calls interrupts one after another, so
+			// that wait would hold up the pty close behind it.
+			defer func() {
+				flushCtx, cancelFlush := context.WithTimeout(context.WithoutCancel(c.ctx), guestFlushTimeout)
+				defer cancelFlush()
+				_ = c.writers.Shutdown(flushCtx)
+			}()
 			defer close(done)
 			_, err := io.Copy(output, uio.NewContextReader(ctx, c.ptmx))
 			return ptyError(err)

--- a/host/internal/fanout_test.go
+++ b/host/internal/fanout_test.go
@@ -1,0 +1,54 @@
+package internal
+
+import (
+	"context"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	uio "github.com/owenthereal/upterm/io"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingWriter accumulates what it is given. The drain runs on its own
+// goroutine, so every field is read under the mutex.
+type recordingWriter struct {
+	mu      sync.Mutex
+	written []byte
+}
+
+func (r *recordingWriter) Write(p []byte) (int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.written = append(r.written, p...)
+	return len(p), nil
+}
+
+func (r *recordingWriter) bytes() []byte {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return slices.Clone(r.written)
+}
+
+// A guest that reaches the door after the fan-out has quiesced is refused, and
+// the sink built for it must not outlive the attempt.
+//
+// The assertion is on the sink, not on the error: checking only ErrClosed would
+// pass just as happily with the release deleted. A closed sink refuses writes,
+// which is the observable consequence of its goroutine being released.
+func TestAttachGuestOutputReleasesTheSinkWhenRefused(t *testing.T) {
+	writers := uio.NewMultiWriter(5)
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	require.NoError(t, writers.Shutdown(ctx))
+
+	var out recordingWriter
+	sink := uio.NewAsyncWriter(&out, uio.DefaultGuestBufferSize, nil)
+
+	require.ErrorIs(t, attachGuestOutput(writers, sink), uio.ErrClosed)
+
+	_, err := sink.Write([]byte("output"))
+	require.ErrorIs(t, err, uio.ErrWriterClosed,
+		"a refused attach must release the sink it was given")
+}

--- a/host/internal/fanout_test.go
+++ b/host/internal/fanout_test.go
@@ -2,6 +2,8 @@ package internal
 
 import (
 	"context"
+	"io"
+	"os"
 	"slices"
 	"sync"
 	"testing"
@@ -51,4 +53,131 @@ func TestAttachGuestOutputReleasesTheSinkWhenRefused(t *testing.T) {
 	_, err := sink.Write([]byte("output"))
 	require.ErrorIs(t, err, uio.ErrWriterClosed,
 		"a refused attach must release the sink it was given")
+}
+
+// delayedWriter always takes longer to deliver than the copy takes to finish,
+// so output is provably still pending when the producer stops. Without the
+// flush, Run returns before this writer has been given anything at all.
+type delayedWriter struct {
+	delay time.Duration
+	rec   *recordingWriter
+}
+
+func (d *delayedWriter) Write(p []byte) (int, error) {
+	time.Sleep(d.delay)
+	return d.rec.Write(p)
+}
+
+// The barrier: by the time Run returns, everything the fan-out accepted has
+// reached the asynchronous guest.
+//
+// Ordering is the whole point. waitIdle returns after 100ms of quiet or its 1s
+// deadline, in both cases with the copy still running, so a flush placed in the
+// interrupt races the producer. Placing it where the copy returns is what makes
+// it a barrier — and asserting *immediately after Run returns*, rather than
+// eventually, is what makes this test notice if it moves back.
+func TestCommandRunFlushesAcceptedOutputBeforeReturning(t *testing.T) {
+	stdinr, stdinw, err := os.Pipe()
+	require.NoError(t, err)
+	defer func() { _ = stdinr.Close() }()
+	defer func() { _ = stdinw.Close() }()
+	stdoutr, stdoutw, err := os.Pipe()
+	require.NoError(t, err)
+	defer func() { _ = stdoutr.Close() }()
+	go func() { _, _ = io.Copy(io.Discard, stdoutr) }()
+
+	const lastLine = "written just before exit"
+
+	var guestOut recordingWriter
+	// 200ms: longer than the copy takes to drain the pty, and well inside
+	// guestFlushTimeout, so the flush both has work to do and can finish it.
+	guest := uio.NewAsyncWriter(&delayedWriter{delay: 200 * time.Millisecond, rec: &guestOut},
+		uio.DefaultGuestBufferSize, nil)
+	defer func() { _ = guest.Close() }()
+
+	writers := uio.NewMultiWriter(5)
+	require.NoError(t, writers.Append(guest))
+
+	cmd := &command{
+		stdin:   stdinr,
+		stdout:  stdoutw,
+		writers: writers,
+		ctx:     t.Context(),
+		ptmx: &exitedPTY{
+			pending:   [][]byte{[]byte("first chunk\r\n"), []byte(lastLine + "\r\n")},
+			readDelay: 20 * time.Millisecond,
+		},
+	}
+
+	require.NoError(t, cmd.Run())
+
+	// No Eventually: the guarantee is that this has already happened.
+	require.Contains(t, string(guestOut.bytes()), lastLine,
+		"Run returned with output still queued for an attached guest")
+}
+
+// The shutdown barrier: waitIdle can return while the producer is still going,
+// and anything produced after that must not be lost.
+//
+// waitIdle has two ways to give up: 100ms of quiet, or its own 1s outer bound
+// regardless of quiet. The idle path cannot leave anything already accepted
+// for this test to check, because the interrupt starts watching from the
+// moment the mock pty's Wait returns -- immediately -- so a gap wide enough
+// to read as quiet is also wide enough to swallow the first chunk before it
+// ever arrives. The chunks here instead arrive well inside that 100ms window,
+// so waitIdle never sees quiet at all; it is only cut off by the 1s deadline,
+// with the pty still holding chunks the copy never got to. That is the other
+// half of "waitIdle does not establish nothing more can be produced": even
+// its own deadline leaves the copy still running when the interrupt cancels
+// it. The comparison is against a synchronous writer attached to the same
+// fan-out, which by definition has everything the fan-out accepted.
+func TestCommandRunLosesNothingWhenTheProducerOutlivesWaitIdle(t *testing.T) {
+	stdinr, stdinw, err := os.Pipe()
+	require.NoError(t, err)
+	defer func() { _ = stdinr.Close() }()
+	defer func() { _ = stdinw.Close() }()
+	stdoutr, stdoutw, err := os.Pipe()
+	require.NoError(t, err)
+	defer func() { _ = stdoutr.Close() }()
+	go func() { _, _ = io.Copy(io.Discard, stdoutr) }()
+
+	var accepted recordingWriter // synchronous: the reference for what got in
+	var guestOut recordingWriter
+	guest := uio.NewAsyncWriter(&delayedWriter{delay: 200 * time.Millisecond, rec: &guestOut},
+		uio.DefaultGuestBufferSize, nil)
+	defer func() { _ = guest.Close() }()
+
+	writers := uio.NewMultiWriter(5)
+	require.NoError(t, writers.Append(&accepted))
+	require.NoError(t, writers.Append(guest))
+
+	var pending [][]byte
+	for i := range 75 {
+		pending = append(pending, []byte{byte('a' + i%26)})
+	}
+	cmd := &command{
+		stdin:   stdinr,
+		stdout:  stdoutw,
+		writers: writers,
+		ctx:     t.Context(),
+		ptmx: &exitedPTY{
+			pending: pending,
+			// waitIdle's clock starts before the very first Read returns, so a
+			// slow first read -- scheduler contention, not design -- competes
+			// with outputIdleTimeout the same way a real mid-stream gap would.
+			// 20ms leaves 80ms of slack for that: a widened margin was the
+			// point of picking this value over a larger one, since a larger
+			// delay leaves less room before the first read is mistaken for
+			// quiet. 75 chunks at this cadence total 1.5s, longer than
+			// outputDrainTimeout, so it is that 1s deadline -- not quiet --
+			// that ends the wait while the copy is still producing.
+			readDelay: 20 * time.Millisecond,
+		},
+	}
+
+	require.NoError(t, cmd.Run())
+
+	require.NotEmpty(t, accepted.bytes())
+	require.Equal(t, string(accepted.bytes()), string(guestOut.bytes()),
+		"output accepted by the fan-out was lost at teardown")
 }

--- a/host/internal/fanout_test.go
+++ b/host/internal/fanout_test.go
@@ -181,3 +181,101 @@ func TestCommandRunLosesNothingWhenTheProducerOutlivesWaitIdle(t *testing.T) {
 	require.Equal(t, string(accepted.bytes()), string(guestOut.bytes()),
 		"output accepted by the fan-out was lost at teardown")
 }
+
+// Under parent cancellation the command and the session handlers would
+// otherwise be released together, so a guest's channel could close while the
+// flush was still delivering into it. Sessions therefore do not inherit the
+// parent's cancellation; only the SSH server actor's interrupt releases them,
+// after giving the command a bounded chance to finish.
+func TestSessionContextSurvivesParentCancellation(t *testing.T) {
+	parent, cancelParent := context.WithCancel(context.Background())
+	sessCtx, cancelSessions := context.WithCancel(sessionContext(parent))
+	defer cancelSessions()
+
+	cancelParent()
+
+	select {
+	case <-sessCtx.Done():
+		t.Fatal("sessions were released by the parent, ahead of the fan-out")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	cancelSessions()
+	select {
+	case <-sessCtx.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("the interrupt must still be able to release sessions")
+	}
+}
+
+func TestWaitClosedReturnsOnCloseAndOnTimeout(t *testing.T) {
+	closed := make(chan struct{})
+	close(closed)
+	start := time.Now()
+	waitClosed(closed, time.Minute)
+	require.Less(t, time.Since(start), time.Second, "an already-closed channel must not wait")
+
+	start = time.Now()
+	waitClosed(make(chan struct{}), 50*time.Millisecond)
+	require.GreaterOrEqual(t, time.Since(start), 50*time.Millisecond,
+		"a command that never finishes must not hold shutdown open forever")
+}
+
+// Cancellation-led shutdown: the sessions must not be released until the
+// fan-out has finished delivering into them.
+//
+// This is the ordering ServeWithContext's last interrupt establishes, tested
+// without the SSH stack because what matters is the sequence, not the
+// transport. It is deterministic because the sink is gated: delivery is
+// provably outstanding when the release is attempted, which a functional test
+// cannot arrange — there, whether anything is still queued depends on window
+// and socket sizes that differ per platform.
+func TestReleaseSessionsWaitsForTheFanOut(t *testing.T) {
+	gate := make(chan struct{})
+	var guestOut recordingWriter
+	guest := uio.NewAsyncWriter(&gatedWriter{gate: gate, rec: &guestOut},
+		uio.DefaultGuestBufferSize, nil)
+	defer func() { _ = guest.Close() }()
+
+	writers := uio.NewMultiWriter(5)
+	require.NoError(t, writers.Append(guest))
+	_, _ = writers.Write([]byte("tail of the session"))
+
+	released := make(chan struct{})
+	cmdDone := make(chan struct{})
+	go func() {
+		defer close(cmdDone)
+		flushCtx, cancel := context.WithTimeout(context.Background(), guestFlushTimeout)
+		defer cancel()
+		_ = writers.Shutdown(flushCtx)
+	}()
+	go func() {
+		defer close(released)
+		releaseSessions(cmdDone, outputDrainTimeout+guestFlushTimeout, func() {})
+	}()
+
+	select {
+	case <-released:
+		t.Fatal("sessions were released while output was still being delivered")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(gate)
+	select {
+	case <-released:
+		require.Equal(t, "tail of the session", string(guestOut.bytes()))
+	case <-time.After(5 * time.Second):
+		t.Fatal("sessions were never released")
+	}
+}
+
+// gatedWriter delivers nothing until its gate is closed.
+type gatedWriter struct {
+	gate <-chan struct{}
+	rec  *recordingWriter
+}
+
+func (g *gatedWriter) Write(p []byte) (int, error) {
+	<-g.gate
+	return g.rec.Write(p)
+}

--- a/host/internal/handle_session_test.go
+++ b/host/internal/handle_session_test.go
@@ -1,0 +1,101 @@
+package internal
+
+import (
+	"io"
+	"testing"
+	"time"
+
+	gssh "charm.land/ssh"
+	"github.com/olebedev/emitter"
+	uio "github.com/owenthereal/upterm/io"
+	"github.com/stretchr/testify/require"
+)
+
+// A read-only guest that is not draining must not hold up its own handler.
+//
+// The banner is the handler's own write to the guest, and it has to travel the
+// same path as everything else the guest receives. Written straight to the
+// session it is a synchronous write to a peer that may not be reading: the
+// handler blocks there before it has started a single actor, and never reaches
+// the teardown that would release it. Through the sink it is queued behind the
+// replay handed over during attach, which is also the only thing that orders
+// the two — a direct write races the sink's goroutine and can arrive ahead of
+// the replay, or between the packets of a chunk already in flight.
+//
+// The stalled guest is what makes this deterministic rather than a race: the
+// blocking path blocks every time.
+func TestHandleSessionDoesNotBlockOnAStalledReadOnlyGuest(t *testing.T) {
+	writers := uio.NewMultiWriter(5)
+	_, err := writers.Write([]byte("output from before this guest joined"))
+	require.NoError(t, err)
+
+	// Never released: the guest stays stalled for the whole test, so anything
+	// written to it directly blocks forever.
+	gate := make(chan struct{})
+	guest := &fakeGuestSession{
+		ctx:   fakeGuestContext{sessionID: "test-session"},
+		winCh: make(chan gssh.Window),
+		out:   &gatedWriter{gate: gate, rec: &recordingWriter{}},
+	}
+
+	h := &sessionHandler{
+		readonly:          true,
+		writers:           writers,
+		eventEmmiter:      emitter.New(1),
+		keepAliveDuration: time.Hour, // long enough never to fire
+		ctx:               t.Context(),
+		logger:            discardLogger(),
+	}
+
+	done := make(chan struct{})
+	go func() { defer close(done); h.HandleSession(guest) }()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("HandleSession blocked writing to a guest that was not draining")
+	}
+}
+
+// fakeGuestSession is the whole of gssh.Session that HandleSession touches:
+// Close, Context, Exit, Pty, SendRequest, and the Read and Write of the
+// embedded channel. The rest is left nil on purpose, so a handler that grows a
+// new dependency on the session panics here instead of passing quietly.
+type fakeGuestSession struct {
+	gssh.Session
+
+	ctx   gssh.Context
+	winCh chan gssh.Window
+	out   io.Writer
+}
+
+// Read reports EOF at once, standing in for a guest that has closed its input.
+// That is what returns the stdin actor and unwinds run.Group, so the handler
+// reaches its end by the route a real departing guest takes.
+func (f *fakeGuestSession) Read([]byte) (int, error) { return 0, io.EOF }
+
+func (f *fakeGuestSession) Write(p []byte) (int, error) { return f.out.Write(p) }
+func (f *fakeGuestSession) Close() error                { return nil }
+func (f *fakeGuestSession) Exit(int) error              { return nil }
+func (f *fakeGuestSession) Context() gssh.Context       { return f.ctx }
+
+func (f *fakeGuestSession) Pty() (gssh.Pty, <-chan gssh.Window, bool) {
+	return gssh.Pty{Term: "xterm"}, f.winCh, true
+}
+
+func (f *fakeGuestSession) SendRequest(string, bool, []byte) (bool, error) { return true, nil }
+
+// fakeGuestContext supplies the one thing HandleSession asks of a session's
+// context, the session ID, and leaves the rest nil for the same reason.
+type fakeGuestContext struct {
+	gssh.Context
+
+	sessionID string
+}
+
+func (c fakeGuestContext) Value(key any) any {
+	if key == gssh.ContextKeySessionID {
+		return c.sessionID
+	}
+	return nil
+}

--- a/host/internal/server.go
+++ b/host/internal/server.go
@@ -379,6 +379,16 @@ func (h *sessionHandler) HandleSession(sess gssh.Session) {
 		})
 	}
 
+	// Everything this handler sends the guest itself goes here rather than to
+	// sess, so it stays behind whatever is already queued for delivery. In the
+	// fan-out path that is the guest's sink: the replay is handed over during
+	// attach and delivered by the sink's goroutine, so a direct write to sess
+	// races it — arriving ahead of the replay, or between the packets of a chunk
+	// already in flight. The forced-command path has no such queue and no
+	// concurrent writer, since its copy is a run.Group actor that has not
+	// started yet.
+	guestOutput := io.Writer(sess)
+
 	if len(h.forceCommand) > 0 {
 		ctx, cancel := context.WithCancel(h.ctx)
 		defer cancel()
@@ -469,6 +479,8 @@ func (h *sessionHandler) HandleSession(sess gssh.Session) {
 			h.writers.Remove(sink)
 			_ = sink.Close()
 		}()
+
+		guestOutput = sink
 	}
 
 	{
@@ -493,7 +505,7 @@ func (h *sessionHandler) HandleSession(sess gssh.Session) {
 	// if a readonly session has been requested, don't connect stdin
 	if h.readonly {
 		// write to client to notify them that they have connected to a read-only session
-		_, _ = io.WriteString(sess, "\r\n=== Attached to read-only session ===\r\n\r\n")
+		_, _ = io.WriteString(guestOutput, "\r\n=== Attached to read-only session ===\r\n\r\n")
 
 		// Still read the client's input, discarding it. Reading is what
 		// tells us the client has gone (EOF), and it keeps the channel

--- a/host/internal/server.go
+++ b/host/internal/server.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -387,13 +388,44 @@ func (h *sessionHandler) HandleSession(sess gssh.Session) {
 		// sequences (like OSC 10/11 color queries, CSI 6n cursor position) before
 		// they reach the client. This prevents client terminals from responding
 		// to queries meant for the host terminal.
-		filteredOutput := uio.NewTerminalQueryFilter(sess)
-		if err := h.writers.Append(filteredOutput); err != nil {
-			_ = sess.Exit(1)
+		filtered := uio.NewTerminalQueryFilter(sess)
+
+		// And wrap that in a sink with its own goroutine and a bounded buffer,
+		// so this guest cannot hold up the fan-out for the host or anyone else.
+		// A guest that overflows is disconnected: a terminal stream is not
+		// resumable, so dropping bytes out of the middle would leave a corrupted
+		// screen it could not detect, while a closed session it can simply
+		// rejoin. See owenthereal/upterm#524.
+		onDrop := func(err error) {
+			if errors.Is(err, uio.ErrOverflow) {
+				h.logger.Warn("dropping guest: too far behind to keep up with output",
+					"session-id", sessionID, "buffer-bytes", uio.DefaultGuestBufferSize)
+			} else {
+				h.logger.Debug("guest output sink failed", "session-id", sessionID, "error", err)
+			}
+			// Closing the channel is what makes the drop real: it fails the
+			// blocked write, and it fails the stdin copy below, so run.Group
+			// returns and the deferred client-left event fires.
+			_ = sess.Close()
+		}
+
+		sink := uio.NewAsyncWriter(filtered, uio.DefaultGuestBufferSize, onDrop)
+		if err := attachGuestOutput(h.writers, sink); err != nil {
+			if errors.Is(err, uio.ErrClosed) {
+				// The session is already tearing down. This guest arrived a
+				// moment too late, which is not its error.
+				_ = sess.Exit(0)
+			} else {
+				h.logger.Error("error attaching guest output", "session-id", sessionID, "error", err)
+				_ = sess.Exit(1)
+			}
 			return
 		}
 
-		defer h.writers.Remove(filteredOutput)
+		defer func() {
+			h.writers.Remove(sink)
+			_ = sink.Close()
+		}()
 	}
 
 	{
@@ -453,6 +485,24 @@ func (h *sessionHandler) HandleSession(sess gssh.Session) {
 	default:
 		_ = sess.Exit(0)
 	}
+}
+
+// attachGuestOutput attaches a guest's sink to the fan-out, releasing it if the
+// fan-out refuses.
+//
+// That release is the one path nothing else covers: the sink's goroutine is
+// idle rather than blocked in I/O, so neither closing the session nor the
+// fan-out's teardown can reach it — and a refused attach became reachable in
+// normal operation the moment MultiWriter learned to quiesce.
+//
+// It takes a built sink rather than building one so the caller, and a test,
+// keeps a handle on what it must release.
+func attachGuestOutput(writers *uio.MultiWriter, sink *uio.AsyncWriter) error {
+	if err := writers.Append(sink); err != nil {
+		_ = sink.Close()
+		return err
+	}
+	return nil
 }
 
 func emitClientJoinEvent(eventEmmiter *emitter.Emitter, sessionID string, auth *server.AuthRequest, pk ssh.PublicKey) {

--- a/host/internal/server.go
+++ b/host/internal/server.go
@@ -190,8 +190,6 @@ func (s *Server) ServeWithContext(ctx context.Context, l net.Listener) error {
 			// released. This is the last interrupt in the group, so waiting
 			// here holds up nothing else, and a command-led exit has already
 			// closed cmdDone by the time it runs.
-			//
-			// kill ssh sessionHandler
 			releaseSessions(cmdDone, outputDrainTimeout+guestFlushTimeout, cancel)
 
 			// shut down ssh server. sessCtx, not ctx: Shutdown waits on its

--- a/host/internal/server.go
+++ b/host/internal/server.go
@@ -46,6 +46,39 @@ type Server struct {
 	SFTPPermissionChecker sftp.PermissionChecker // Optional: prompts user for SFTP permissions (nil = auto-allow)
 }
 
+// sessionContext derives the context guest sessions live under.
+//
+// It is deliberately detached from the parent. The fan-out's final flush
+// happens as the command's output copy returns, and a session context that died
+// with the parent would let HandleSession close a guest's channel while that
+// flush was still writing into it. Only the SSH server actor's interrupt
+// releases sessions, and it does so after giving the command a bounded chance
+// to finish.
+func sessionContext(ctx context.Context) context.Context {
+	return context.WithoutCancel(ctx)
+}
+
+// waitClosed waits for done, giving up after timeout.
+func waitClosed(done <-chan struct{}, timeout time.Duration) {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-done:
+	case <-timer.C:
+	}
+}
+
+// releaseSessions holds guest sessions open until the fan-out has finished
+// delivering into them, then releases them.
+//
+// Named rather than inlined into the interrupt so the ordering it establishes
+// can be tested on its own: it is the half of the mechanism that a detached
+// session context is useless without.
+func releaseSessions(cmdDone <-chan struct{}, timeout time.Duration, release func()) {
+	waitClosed(cmdDone, timeout)
+	release()
+}
+
 func (s *Server) ServeWithContext(ctx context.Context, l net.Listener) error {
 	writers := uio.NewMultiWriter(5)
 
@@ -67,6 +100,7 @@ func (s *Server) ServeWithContext(ctx context.Context, l net.Listener) error {
 	}
 
 	var g run.Group
+	cmdDone := make(chan struct{})
 	{
 		ctx, cancel := context.WithCancel(ctx)
 		teh := terminalEventHandler{
@@ -81,20 +115,21 @@ func (s *Server) ServeWithContext(ctx context.Context, l net.Listener) error {
 	}
 	{
 		g.Add(func() error {
+			defer close(cmdDone)
 			return cmd.Run()
 		}, func(err error) {
 			cmdCancel()
 		})
 	}
 	{
-		ctx, cancel := context.WithCancel(ctx)
+		sessCtx, cancel := context.WithCancel(sessionContext(ctx))
 		sh := sessionHandler{
 			forceCommand:          s.ForceCommand,
 			ptmx:                  ptmx,
 			eventEmmiter:          s.EventEmitter,
 			writers:               writers,
 			keepAliveDuration:     s.KeepAliveDuration,
-			ctx:                   ctx,
+			ctx:                   sessCtx,
 			logger:                s.Logger,
 			readonly:              s.ReadOnly,
 			sftpPermissionChecker: s.SFTPPermissionChecker,
@@ -151,10 +186,20 @@ func (s *Server) ServeWithContext(ctx context.Context, l net.Listener) error {
 		g.Add(func() error {
 			return server.Serve(l)
 		}, func(err error) {
+			// Let the fan-out finish delivering before the sessions are
+			// released. This is the last interrupt in the group, so waiting
+			// here holds up nothing else, and a command-led exit has already
+			// closed cmdDone by the time it runs.
+			//
 			// kill ssh sessionHandler
-			cancel()
-			// shut down ssh server
-			_ = server.Shutdown(ctx)
+			releaseSessions(cmdDone, outputDrainTimeout+guestFlushTimeout, cancel)
+
+			// shut down ssh server. sessCtx, not ctx: Shutdown waits on its
+			// connection WaitGroup until the context it is given is done, and
+			// on a command-led exit ctx is still live — a guest that keeps its
+			// SSH connection open after its channel closed would hang the host
+			// forever, and the deferred ReverseTunnel.Close would never run.
+			_ = server.Shutdown(sessCtx)
 		})
 	}
 

--- a/io/async_writer.go
+++ b/io/async_writer.go
@@ -1,0 +1,213 @@
+package io
+
+import (
+	"errors"
+	"io"
+	"sync"
+)
+
+const (
+	// DefaultGuestBufferSize is how much undelivered output one guest may hold
+	// before it is dropped. It is generous on purpose: a stalled guest already
+	// sits behind up to 2 MiB of SSH window on each of the two legs between the
+	// host and itself, so it is megabytes behind before this is reached. The
+	// buffer exists to decouple the fan-out from a blocking write, not to store
+	// the session.
+	DefaultGuestBufferSize = 1 << 20 // 1 MiB
+)
+
+var (
+	// ErrOverflow is returned once a sink has passed its cap. A guest that
+	// cannot receive output is not attached in any useful sense, so the sink
+	// fails permanently rather than dropping bytes out of the middle of a
+	// terminal stream, which the guest could not detect.
+	ErrOverflow = errors.New("asyncwriter: buffer overflow")
+
+	// ErrWriterClosed is returned by Write after Close.
+	ErrWriterClosed = errors.New("asyncwriter: closed")
+)
+
+// AsyncWriter delivers to one writer from one goroutine, so writing to it never
+// blocks on that writer's I/O.
+//
+// It exists because the host fans its pty output out to every guest serially:
+// a guest that stops reading its SSH channel blocks in Write once the channel
+// window fills, and holds up every writer behind it, including the host's own
+// terminal. Handing off into a bounded buffer means the slowest viewer no
+// longer sets the pace. See owenthereal/upterm#524.
+//
+// The buffer is bounded in bytes rather than in writes, because pty writes run
+// from one byte to io.Copy's 32 KiB and a count of writes is therefore not a
+// bound on memory at all.
+type AsyncWriter struct {
+	w      io.Writer
+	max    int
+	onDrop func(error)
+
+	// chunk is owned by the drain goroutine and never aliases pending. Handing
+	// out a sub-slice of pending instead would pin its whole grown backing
+	// array for the length of the write and defeat the release below.
+	chunk []byte
+
+	mu      sync.Mutex
+	cond    *sync.Cond
+	pending []byte
+	err     error
+	closed  bool
+	writing bool
+	// idle is closed and replaced every time the drain catches up, which is how
+	// Flush waits without polling. See flush.go.
+	idle     chan struct{}
+	dropOnce sync.Once
+	done     chan struct{}
+}
+
+// NewAsyncWriter starts delivery to w immediately. max bounds the payload held
+// undelivered; onDrop, which may be nil, is called once if the sink dies,
+// always on its own goroutine so the caller of Write is never held up by it.
+//
+// The caller owns w. Close stops the goroutine but does not close w.
+func NewAsyncWriter(w io.Writer, max int, onDrop func(error)) *AsyncWriter {
+	a := &AsyncWriter{
+		w:      w,
+		max:    max,
+		onDrop: onDrop,
+		chunk:  make([]byte, maxDrainChunk),
+		idle:   make(chan struct{}),
+		done:   make(chan struct{}),
+	}
+	a.cond = sync.NewCond(&a.mu)
+	go a.drain()
+	return a
+}
+
+// Write copies p into the pending buffer and returns. It never performs I/O and
+// never blocks on the underlying writer.
+//
+// It reports overflow as an error so that MultiWriter, which already drops a
+// writer that fails, removes this one without needing to know anything about
+// buffering.
+func (a *AsyncWriter) Write(p []byte) (int, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	switch {
+	case a.err != nil:
+		return 0, a.err
+	case a.closed:
+		return 0, ErrWriterClosed
+	case len(a.pending)+len(p) > a.max:
+		a.fail(ErrOverflow)
+		return 0, a.err
+	}
+
+	// The copy is not optional: io.Copy reuses its buffer, so retaining p would
+	// corrupt this guest's output as soon as the copy looped.
+	a.pending = append(a.pending, p...)
+	a.cond.Broadcast()
+	return len(p), nil
+}
+
+// Close stops accepting writes and signals the drain. It deliberately does not
+// wait for the goroutine to exit: in the case this type exists for, that
+// goroutine is blocked in a write that only session teardown will release, and
+// waiting here would deadlock exactly then. The goroutine exits when its
+// in-flight write returns.
+//
+// Close always returns nil and is safe to call repeatedly. Pending bytes are
+// discarded; MultiWriter.Shutdown is the path that delivers a tail.
+func (a *AsyncWriter) Close() error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if !a.closed {
+		a.closed = true
+		a.cond.Broadcast()
+		a.signalIdle()
+	}
+	return nil
+}
+
+// fail records a terminal error and releases everything waiting on this sink.
+// Callers must hold a.mu.
+//
+// onDrop runs on its own goroutine because the caller here is the pty copy that
+// feeds every attached guest: a callback that blocks would reintroduce the head
+// -of-line blocking this type removes.
+func (a *AsyncWriter) fail(err error) {
+	if a.err != nil {
+		return
+	}
+	a.err = err
+	a.pending = nil
+	a.cond.Broadcast()
+	a.signalIdle()
+	if a.onDrop != nil {
+		a.dropOnce.Do(func() { go a.onDrop(err) })
+	}
+}
+
+// signalIdle releases anything waiting for delivery to catch up. Callers must
+// hold a.mu.
+func (a *AsyncWriter) signalIdle() {
+	close(a.idle)
+	a.idle = make(chan struct{})
+}
+
+func (a *AsyncWriter) drain() {
+	defer close(a.done)
+	for {
+		a.mu.Lock()
+		for len(a.pending) == 0 && !a.closed && a.err == nil {
+			a.cond.Wait()
+		}
+		if a.closed || a.err != nil {
+			a.mu.Unlock()
+			return
+		}
+		n := a.takeChunk()
+		a.writing = true
+		a.mu.Unlock()
+
+		written, err := a.w.Write(a.chunk[:n])
+		if err == nil && written != n {
+			// MultiWriter refuses a short write from an attached writer, and
+			// wrapping the guest in a sink must not quietly give that up:
+			// accepting it would truncate the stream and leave the guest
+			// attached, which is worse than dropping it.
+			err = io.ErrShortWrite
+		}
+
+		a.mu.Lock()
+		a.writing = false
+		if err != nil {
+			a.fail(err)
+			a.mu.Unlock()
+			return
+		}
+		if len(a.pending) == 0 {
+			a.signalIdle()
+		}
+		a.mu.Unlock()
+	}
+}
+
+// stopped reports whether the drain goroutine has exited. It exists so tests
+// can assert the goroutine is not leaked without reaching into unexported state.
+func (a *AsyncWriter) stopped() bool {
+	select {
+	case <-a.done:
+		return true
+	default:
+		return false
+	}
+}
+
+const maxDrainChunk = 64 << 10 // 64 KiB
+
+// takeChunk moves pending bytes into the goroutine's own buffer. Callers must
+// hold a.mu.
+func (a *AsyncWriter) takeChunk() int {
+	n := copy(a.chunk, a.pending)
+	a.pending = a.pending[n:]
+	return n
+}

--- a/io/async_writer.go
+++ b/io/async_writer.go
@@ -10,11 +10,14 @@ import (
 const (
 	// DefaultGuestBufferSize bounds how much output may sit in pending before a
 	// guest is dropped; the worst case for undelivered output is this plus one
-	// in-flight maxDrainChunk. It is generous on purpose: a stalled guest already
-	// sits behind up to 2 MiB of SSH window on each of the two legs between the
-	// host and itself, so it is megabytes behind before this is reached. The
-	// buffer exists to decouple the fan-out from a blocking write, not to store
-	// the session.
+	// in-flight maxDrainChunk. A guest merely slower than the host's terminal,
+	// rather than stalled, is throttled only by the host's own ingest rate, so
+	// backlog accrues at the difference between that rate and the guest's
+	// drain rate, and a sustained mismatch exhausts any finite cap: this
+	// number sets how long a slow guest survives, not whether. Total slack is
+	// roughly 5 MiB, the cap plus a 2 MiB SSH window on each of the two legs
+	// between host and guest. The buffer exists to decouple the fan-out from a
+	// blocking write, not to store the session.
 	DefaultGuestBufferSize = 1 << 20 // 1 MiB
 )
 

--- a/io/async_writer.go
+++ b/io/async_writer.go
@@ -127,6 +127,7 @@ func (a *AsyncWriter) Close() error {
 	defer a.mu.Unlock()
 	if !a.closed {
 		a.closed = true
+		a.pending = nil
 		a.cond.Broadcast()
 		a.signalIdle()
 	}
@@ -238,8 +239,19 @@ const maxDrainChunk = 64 << 10 // 64 KiB
 
 // takeChunk moves pending bytes into the goroutine's own buffer. Callers must
 // hold a.mu.
+//
+// Dropping the slice once it empties is what gives the burst's memory back.
+// Advancing past the bytes taken shrinks the slice's length and capacity but
+// leaves its pointer inside the array append grew, and Go frees an allocation
+// only as a whole: a guest that caught up after a 512 KiB burst and then went
+// quiet would hold every byte of it until some later write happened to
+// reallocate. Measured over that burst in io.Copy-sized appends: 589 KiB still
+// resident after a full drain, 5 KiB once pending is dropped.
 func (a *AsyncWriter) takeChunk() int {
 	n := copy(a.chunk, a.pending)
 	a.pending = a.pending[n:]
+	if len(a.pending) == 0 {
+		a.pending = nil
+	}
 	return n
 }

--- a/io/async_writer.go
+++ b/io/async_writer.go
@@ -7,8 +7,9 @@ import (
 )
 
 const (
-	// DefaultGuestBufferSize is how much undelivered output one guest may hold
-	// before it is dropped. It is generous on purpose: a stalled guest already
+	// DefaultGuestBufferSize bounds how much output may sit in pending before a
+	// guest is dropped; the worst case for undelivered output is this plus one
+	// in-flight maxDrainChunk. It is generous on purpose: a stalled guest already
 	// sits behind up to 2 MiB of SSH window on each of the two legs between the
 	// host and itself, so it is megabytes behind before this is reached. The
 	// buffer exists to decouple the fan-out from a blocking write, not to store
@@ -46,7 +47,8 @@ type AsyncWriter struct {
 
 	// chunk is owned by the drain goroutine and never aliases pending. Handing
 	// out a sub-slice of pending instead would pin its whole grown backing
-	// array for the length of the write and defeat the release below.
+	// array for the length of the write, which is exactly what
+	// TestAsyncWriterChunkStaysABoundedBuffer guards against.
 	chunk []byte
 
 	mu      sync.Mutex
@@ -56,7 +58,7 @@ type AsyncWriter struct {
 	closed  bool
 	writing bool
 	// idle is closed and replaced every time the drain catches up, which is how
-	// Flush waits without polling. See flush.go.
+	// Flush waits without polling.
 	idle     chan struct{}
 	dropOnce sync.Once
 	done     chan struct{}
@@ -131,8 +133,8 @@ func (a *AsyncWriter) Close() error {
 // Callers must hold a.mu.
 //
 // onDrop runs on its own goroutine because the caller here is the pty copy that
-// feeds every attached guest: a callback that blocks would reintroduce the head
-// -of-line blocking this type removes.
+// feeds every attached guest: a callback that blocks would reintroduce the
+// head-of-line blocking this type removes.
 func (a *AsyncWriter) fail(err error) {
 	if a.err != nil {
 		return

--- a/io/async_writer.go
+++ b/io/async_writer.go
@@ -1,6 +1,7 @@
 package io
 
 import (
+	"context"
 	"errors"
 	"io"
 	"sync"
@@ -127,6 +128,32 @@ func (a *AsyncWriter) Close() error {
 		a.signalIdle()
 	}
 	return nil
+}
+
+// Flush waits until everything written so far has been delivered, or until ctx
+// is done.
+//
+// It waits on the idle signal the drain publishes once it has emptied the
+// buffer and its last write has returned, rather than polling, and it honours
+// ctx so that one stuck guest cannot hold up the host's exit. A dead or closed
+// sink flushes to nil: there is nothing left to deliver and a guest that is
+// already gone is not a shutdown error.
+func (a *AsyncWriter) Flush(ctx context.Context) error {
+	for {
+		a.mu.Lock()
+		if a.err != nil || a.closed || (len(a.pending) == 0 && !a.writing) {
+			a.mu.Unlock()
+			return nil
+		}
+		idle := a.idle
+		a.mu.Unlock()
+
+		select {
+		case <-idle:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
 }
 
 // fail records a terminal error and releases everything waiting on this sink.

--- a/io/async_writer_test.go
+++ b/io/async_writer_test.go
@@ -2,6 +2,7 @@ package io
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"slices"
 	"sync"
@@ -349,4 +350,78 @@ func TestAsyncWriterChunkStaysABoundedBuffer(t *testing.T) {
 	close(gate.release)
 	require.Eventually(t, func() bool { return len(gate.bytes()) == burst },
 		5*time.Second, time.Millisecond, "all bytes delivered")
+}
+
+func TestAsyncWriterFlushReturnsWhenIdle(t *testing.T) {
+	var rec recordingWriter
+	a := NewAsyncWriter(&rec, DefaultGuestBufferSize, nil)
+	defer func() { _ = a.Close() }()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	require.NoError(t, a.Flush(ctx), "an idle sink flushes immediately")
+}
+
+func TestAsyncWriterFlushWaitsForDelivery(t *testing.T) {
+	gate := newGateWriter()
+	a := NewAsyncWriter(gate, DefaultGuestBufferSize, nil)
+	defer func() { _ = a.Close() }()
+
+	_, err := a.Write([]byte("tail of the session"))
+	require.NoError(t, err)
+	<-gate.entered
+
+	flushed := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		flushed <- a.Flush(ctx)
+	}()
+
+	select {
+	case <-flushed:
+		t.Fatal("Flush returned before delivery completed")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(gate.release)
+	select {
+	case err := <-flushed:
+		require.NoError(t, err)
+		require.Equal(t, "tail of the session", string(gate.bytes()))
+	case <-time.After(5 * time.Second):
+		t.Fatal("Flush never returned after delivery")
+	}
+}
+
+func TestAsyncWriterFlushGivesUpOnAStuckSink(t *testing.T) {
+	gate := newGateWriter()
+	defer close(gate.release)
+
+	a := NewAsyncWriter(gate, DefaultGuestBufferSize, nil)
+	defer func() { _ = a.Close() }()
+
+	_, err := a.Write([]byte("never delivered"))
+	require.NoError(t, err)
+	<-gate.entered
+
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+	require.ErrorIs(t, a.Flush(ctx), context.DeadlineExceeded,
+		"a stuck guest must not hold up shutdown")
+}
+
+func TestAsyncWriterFlushAfterCloseReturnsImmediately(t *testing.T) {
+	gate := newGateWriter()
+	defer close(gate.release)
+
+	a := NewAsyncWriter(gate, DefaultGuestBufferSize, nil)
+	_, err := a.Write([]byte("discarded"))
+	require.NoError(t, err)
+	<-gate.entered
+	require.NoError(t, a.Close())
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	require.NoError(t, a.Flush(ctx))
 }

--- a/io/async_writer_test.go
+++ b/io/async_writer_test.go
@@ -264,3 +264,89 @@ func TestAsyncWriterCloseDoesNotWaitAndStopsTheDrain(t *testing.T) {
 	require.Eventually(t, func() bool { return a.stopped() },
 		2*time.Second, time.Millisecond, "the drain goroutine must exit")
 }
+
+func TestAsyncWriterCoalescesUpToTheChunkCap(t *testing.T) {
+	gate := newGateWriter()
+	a := NewAsyncWriter(gate, DefaultGuestBufferSize, nil)
+	defer func() { _ = a.Close() }()
+
+	_, err := a.Write([]byte("first"))
+	require.NoError(t, err)
+	<-gate.entered // the drain holds "first"; everything below queues behind it
+
+	block := bytes.Repeat([]byte("y"), 32<<10)
+	const blocks = 8 // 256 KiB, four chunks' worth
+	for range blocks {
+		_, err := a.Write(block)
+		require.NoError(t, err)
+	}
+
+	close(gate.release)
+	wantLen := len("first") + blocks*len(block)
+	require.Eventually(t, func() bool { return len(gate.bytes()) == wantLen },
+		5*time.Second, time.Millisecond, "everything queued must be delivered")
+
+	sizes := gate.writeSizes()
+	require.Less(t, len(sizes), blocks, "queued writes should coalesce, not arrive one by one")
+	for _, n := range sizes {
+		require.LessOrEqual(t, n, maxDrainChunk, "no write may exceed the chunk cap")
+	}
+}
+
+// A burst that has been fully delivered must not leave its backing array behind
+// for the rest of the session. Advancing pending past the bytes taken walks the
+// slice to the end of its array, so this holds without any explicit release —
+// measured at 0-4096 bytes across bursts from 256 KiB to 1000 KiB. The bound
+// here is deliberately loose: it pins "the array is given back", not the exact
+// arithmetic of Go's size classes.
+func TestAsyncWriterReleasesPendingCapacityWhenItCatchesUp(t *testing.T) {
+	gate := newGateWriter()
+	a := NewAsyncWriter(gate, DefaultGuestBufferSize, nil)
+	defer func() { _ = a.Close() }()
+
+	_, err := a.Write([]byte("first"))
+	require.NoError(t, err)
+	<-gate.entered
+
+	_, err = a.Write(bytes.Repeat([]byte("z"), 512<<10))
+	require.NoError(t, err)
+
+	close(gate.release)
+	require.Eventually(t, func() bool {
+		a.mu.Lock()
+		defer a.mu.Unlock()
+		return len(a.pending) == 0 && cap(a.pending) <= maxDrainChunk
+	}, 5*time.Second, time.Millisecond, "a one-off burst must not be retained for the session")
+}
+
+// The drain's chunk must stay a bounded buffer of its own rather than a window
+// into pending: `a.chunk = a.pending[:n]` would keep the guest's whole grown
+// array — up to max — reachable for as long as the write is in flight, which is
+// the memory term the 64 KiB cap exists to bound.
+//
+// This pins memory, not content. Delivered bytes cannot be rewritten under the
+// writer either way: pending only ever advances past the bytes taken, so every
+// later append lands beyond the range a window would cover. A content
+// comparison therefore cannot tell a copy from a window — capacity can.
+func TestAsyncWriterChunkStaysABoundedBuffer(t *testing.T) {
+	gate := newGateWriter()
+	a := NewAsyncWriter(gate, DefaultGuestBufferSize, nil)
+	defer func() { _ = a.Close() }()
+
+	// A burst far larger than one chunk, so a windowing takeChunk would inherit
+	// a correspondingly large capacity.
+	const burst = 512 << 10
+	_, err := a.Write(bytes.Repeat([]byte("a"), burst))
+	require.NoError(t, err)
+	<-gate.entered // the drain is inside Write, holding the first chunk
+
+	a.mu.Lock()
+	chunkCap := cap(a.chunk)
+	a.mu.Unlock()
+	require.Equal(t, maxDrainChunk, chunkCap,
+		"the chunk must not inherit pending's backing array")
+
+	close(gate.release)
+	require.Eventually(t, func() bool { return len(gate.bytes()) == burst },
+		5*time.Second, time.Millisecond, "all bytes delivered")
+}

--- a/io/async_writer_test.go
+++ b/io/async_writer_test.go
@@ -1,0 +1,266 @@
+package io
+
+import (
+	"bytes"
+	"io"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// recordingWriter accumulates what it is given. The drain runs on its own
+// goroutine, so every field is read under the mutex.
+type recordingWriter struct {
+	mu      sync.Mutex
+	written []byte
+	sizes   []int
+}
+
+func (r *recordingWriter) Write(p []byte) (int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.written = append(r.written, p...)
+	r.sizes = append(r.sizes, len(p))
+	return len(p), nil
+}
+
+func (r *recordingWriter) bytes() []byte {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return slices.Clone(r.written)
+}
+
+func (r *recordingWriter) writeSizes() []int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return slices.Clone(r.sizes)
+}
+
+// gateWriter models a guest whose SSH channel window has filled: every Write
+// blocks until the test releases it. entered closes on the first Write so a
+// test can wait for the drain to actually be inside the writer rather than for
+// its goroutine to be scheduled.
+type gateWriter struct {
+	recordingWriter
+	once    sync.Once
+	entered chan struct{}
+	release chan struct{}
+}
+
+func newGateWriter() *gateWriter {
+	return &gateWriter{entered: make(chan struct{}), release: make(chan struct{})}
+}
+
+func (g *gateWriter) Write(p []byte) (int, error) {
+	g.once.Do(func() { close(g.entered) })
+	<-g.release
+	return g.recordingWriter.Write(p)
+}
+
+// The property the whole change rests on: the fan-out hands off instead of
+// waiting for a guest that has stopped reading.
+func TestAsyncWriterWriteDoesNotBlockOnStuckWriter(t *testing.T) {
+	gate := newGateWriter()
+	defer close(gate.release)
+
+	a := NewAsyncWriter(gate, DefaultGuestBufferSize, nil)
+	defer func() { _ = a.Close() }()
+
+	_, err := a.Write([]byte("first"))
+	require.NoError(t, err)
+	<-gate.entered // the drain is now blocked inside the writer
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for range 100 {
+			_, _ = a.Write([]byte("more output"))
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Write blocked behind a stuck writer")
+	}
+}
+
+func TestAsyncWriterDeliversInOrder(t *testing.T) {
+	var rec recordingWriter
+	a := NewAsyncWriter(&rec, DefaultGuestBufferSize, nil)
+	defer func() { _ = a.Close() }()
+
+	var want []byte
+	for i := range 50 {
+		p := []byte{byte('a' + i%26)}
+		want = append(want, p...)
+		_, err := a.Write(p)
+		require.NoError(t, err)
+	}
+
+	require.Eventually(t, func() bool { return bytes.Equal(rec.bytes(), want) },
+		2*time.Second, time.Millisecond, "bytes should arrive in order and intact")
+}
+
+// io.Copy reuses its buffer, so a sink that retained p would corrupt output for
+// every attached guest the moment the copy looped.
+func TestAsyncWriterCopiesTheCallersBuffer(t *testing.T) {
+	gate := newGateWriter()
+	a := NewAsyncWriter(gate, DefaultGuestBufferSize, nil)
+	defer func() { _ = a.Close() }()
+
+	buf := []byte("original")
+	_, err := a.Write(buf)
+	require.NoError(t, err)
+	copy(buf, "OVERWRIT")
+
+	close(gate.release)
+	require.Eventually(t, func() bool { return string(gate.bytes()) == "original" },
+		2*time.Second, time.Millisecond, "the sink must not alias the caller's buffer")
+}
+
+func TestAsyncWriterOverflowDropsOnce(t *testing.T) {
+	gate := newGateWriter()
+	defer close(gate.release)
+
+	drops := make(chan error, 4)
+	a := NewAsyncWriter(gate, 16, func(err error) { drops <- err })
+	defer func() { _ = a.Close() }()
+
+	_, err := a.Write([]byte("12345678"))
+	require.NoError(t, err)
+	<-gate.entered
+
+	// The first 8 bytes are in flight, so the cap applies to what follows.
+	_, err = a.Write([]byte("12345678"))
+	require.NoError(t, err)
+	_, err = a.Write([]byte("123456789"))
+	require.ErrorIs(t, err, ErrOverflow, "writing past the cap must fail")
+
+	select {
+	case err := <-drops:
+		require.ErrorIs(t, err, ErrOverflow)
+	case <-time.After(2 * time.Second):
+		t.Fatal("onDrop never fired")
+	}
+
+	_, err = a.Write([]byte("x"))
+	require.ErrorIs(t, err, ErrOverflow, "the error must be sticky")
+
+	select {
+	case <-drops:
+		t.Fatal("onDrop fired more than once")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+// onDrop runs on the pty copy's behalf, so it must never be able to hold it up.
+func TestAsyncWriterSlowDropCallbackDoesNotBlockWrite(t *testing.T) {
+	gate := newGateWriter()
+	defer close(gate.release)
+
+	blocked := make(chan struct{})
+	defer close(blocked)
+	a := NewAsyncWriter(gate, 8, func(error) { <-blocked })
+	defer func() { _ = a.Close() }()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = a.Write([]byte("0123456789"))
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Write blocked behind onDrop")
+	}
+}
+
+func TestAsyncWriterUnderlyingErrorIsTreatedAsADrop(t *testing.T) {
+	drops := make(chan error, 1)
+	a := NewAsyncWriter(&failingWriter{}, DefaultGuestBufferSize, func(err error) { drops <- err })
+	defer func() { _ = a.Close() }()
+
+	_, err := a.Write([]byte("output"))
+	require.NoError(t, err, "the failure surfaces on the drain, not this write")
+
+	select {
+	case err := <-drops:
+		require.Error(t, err)
+		require.NotErrorIs(t, err, ErrOverflow)
+	case <-time.After(2 * time.Second):
+		t.Fatal("onDrop never fired for an underlying write error")
+	}
+
+	require.Eventually(t, func() bool {
+		_, err := a.Write([]byte("more"))
+		return err != nil
+	}, 2*time.Second, time.Millisecond, "later writes must fail once the sink is dead")
+}
+
+// MultiWriter treats a short write as a failed writer, and wrapping the guest
+// in a sink must not quietly give that up: a writer that reports n < len(p)
+// with no error would otherwise truncate the stream and stay attached.
+func TestAsyncWriterShortWriteIsADrop(t *testing.T) {
+	drops := make(chan error, 1)
+	a := NewAsyncWriter(shortWriter{}, DefaultGuestBufferSize, func(err error) { drops <- err })
+	defer func() { _ = a.Close() }()
+
+	_, err := a.Write([]byte("output"))
+	require.NoError(t, err)
+
+	select {
+	case err := <-drops:
+		require.ErrorIs(t, err, io.ErrShortWrite)
+	case <-time.After(2 * time.Second):
+		t.Fatal("a short write was accepted as complete delivery")
+	}
+}
+
+// shortWriter accepts everything but the last byte, without reporting an error.
+type shortWriter struct{}
+
+func (shortWriter) Write(p []byte) (int, error) { return len(p) - 1, nil }
+
+// An idle drain has no I/O to fail, so Close is the only thing that can ever
+// release it. This is the refused-attach path: the sink is built, the attach is
+// rejected, and nothing was ever written.
+func TestAsyncWriterCloseStopsAnIdleDrain(t *testing.T) {
+	var rec recordingWriter
+	a := NewAsyncWriter(&rec, DefaultGuestBufferSize, nil)
+
+	require.NoError(t, a.Close())
+	require.Eventually(t, a.stopped, 2*time.Second, time.Millisecond,
+		"an idle drain must exit on Close")
+}
+
+// Close must not wait for the goroutine: in the case this whole change exists
+// for, that goroutine is blocked in a write that only session teardown releases.
+func TestAsyncWriterCloseDoesNotWaitAndStopsTheDrain(t *testing.T) {
+	gate := newGateWriter()
+	a := NewAsyncWriter(gate, DefaultGuestBufferSize, nil)
+
+	_, err := a.Write([]byte("first"))
+	require.NoError(t, err)
+	<-gate.entered
+
+	done := make(chan struct{})
+	go func() { defer close(done); _ = a.Close() }()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close waited for a goroutine blocked in a write")
+	}
+
+	_, err = a.Write([]byte("after close"))
+	require.ErrorIs(t, err, ErrWriterClosed)
+	require.NoError(t, a.Close(), "Close must be repeatable")
+
+	close(gate.release) // release the in-flight write
+	require.Eventually(t, func() bool { return a.stopped() },
+		2*time.Second, time.Millisecond, "the drain goroutine must exit")
+}

--- a/io/async_writer_test.go
+++ b/io/async_writer_test.go
@@ -295,29 +295,64 @@ func TestAsyncWriterCoalescesUpToTheChunkCap(t *testing.T) {
 }
 
 // A burst that has been fully delivered must not leave its backing array behind
-// for the rest of the session. Advancing pending past the bytes taken walks the
-// slice to the end of its array, so this holds without any explicit release —
-// measured at 0-4096 bytes across bursts from 256 KiB to 1000 KiB. The bound
-// here is deliberately loose: it pins "the array is given back", not the exact
-// arithmetic of Go's size classes.
-func TestAsyncWriterReleasesPendingCapacityWhenItCatchesUp(t *testing.T) {
+// for the rest of the session.
+//
+// The assertion is that pending is nil, not that its capacity is small, because
+// capacity is not what holds the memory. Advancing past the bytes taken shrinks
+// length and capacity but leaves the slice pointing inside the array append
+// grew, and Go frees an allocation only as a whole. Under this burst, written
+// the way io.Copy writes it, re-slicing alone ends at 72 KiB of capacity with
+// 589 KiB still resident; dropping the slice returns all but 5 KiB. A nil slice
+// holds no pointer, so nil is the release.
+func TestAsyncWriterReleasesPendingBufferWhenItCatchesUp(t *testing.T) {
 	gate := newGateWriter()
 	a := NewAsyncWriter(gate, DefaultGuestBufferSize, nil)
 	defer func() { _ = a.Close() }()
 
 	_, err := a.Write([]byte("first"))
 	require.NoError(t, err)
-	<-gate.entered
+	<-gate.entered // the drain is parked in the writer, so the burst piles up behind it
 
-	_, err = a.Write(bytes.Repeat([]byte("z"), 512<<10))
-	require.NoError(t, err)
+	// Written at io.Copy's chunk size rather than in one call: growing by
+	// repeated append is what leaves pending owning an array far larger than the
+	// bytes it still owes.
+	block := bytes.Repeat([]byte("z"), 32<<10)
+	for written := 0; written < 512<<10; written += len(block) {
+		_, err = a.Write(block)
+		require.NoError(t, err)
+	}
 
 	close(gate.release)
 	require.Eventually(t, func() bool {
 		a.mu.Lock()
 		defer a.mu.Unlock()
-		return len(a.pending) == 0 && cap(a.pending) <= maxDrainChunk
+		return a.pending == nil
 	}, 5*time.Second, time.Millisecond, "a one-off burst must not be retained for the session")
+}
+
+// Close discards what it never delivered, and discarding means releasing: a
+// sink closed mid-burst that stayed reachable — through a deferred Close, or a
+// caller still holding it — would otherwise pin the whole buffer.
+func TestAsyncWriterCloseReleasesUndeliveredOutput(t *testing.T) {
+	gate := newGateWriter()
+	defer close(gate.release)
+
+	a := NewAsyncWriter(gate, DefaultGuestBufferSize, nil)
+
+	_, err := a.Write([]byte("first"))
+	require.NoError(t, err)
+	<-gate.entered // the drain is parked, so nothing below is delivered
+
+	_, err = a.Write(bytes.Repeat([]byte("z"), 512<<10))
+	require.NoError(t, err)
+
+	require.NoError(t, a.Close())
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	// Compared rather than passed to require.Nil: the failure is a held buffer,
+	// and require.Nil would render every byte of it.
+	require.True(t, a.pending == nil, "Close must release the output it discards")
 }
 
 // The drain's chunk must stay a bounded buffer of its own rather than a window

--- a/io/writer.go
+++ b/io/writer.go
@@ -1,6 +1,7 @@
 package io
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -54,6 +55,17 @@ func NewMultiWriter(bufferSize int, writers ...io.Writer) *MultiWriter {
 	}
 }
 
+// ErrClosed is returned by Append once Shutdown has run. A guest that reaches
+// the door as the session is ending is refused rather than attached to a
+// fan-out nothing will flush again.
+var ErrClosed = errors.New("multiwriter: closed to new writers")
+
+// Flusher is implemented by attached writers that deliver asynchronously and so
+// can still be holding output when the producer stops.
+type Flusher interface {
+	Flush(ctx context.Context) error
+}
+
 // MultiWriter is a concurrent safe writer that allows appending/removing writers.
 // Newly appended writers get the last write to preserve last output.
 //
@@ -73,6 +85,11 @@ type MultiWriter struct {
 	writers   []io.Writer
 
 	buffer *buffer
+
+	// closed is guarded by writeMu, so Shutdown's quiesce and a concurrent
+	// Append cannot interleave: an attach in progress either completes before
+	// the snapshot and is flushed, or finds this set and is refused.
+	closed bool
 }
 
 // Append attaches writers, handing each the replay buffer first so it starts
@@ -95,6 +112,10 @@ func (t *MultiWriter) Append(writers ...io.Writer) error {
 
 	t.writeMu.Lock()
 	defer t.writeMu.Unlock()
+
+	if t.closed {
+		return ErrClosed
+	}
 
 	for _, w := range writers {
 		for _, d := range t.buffer.Data() {
@@ -210,4 +231,46 @@ func (t *MultiWriter) Write(p []byte) (int, error) {
 	}
 
 	return len(p), nil
+}
+
+// Shutdown closes the fan-out to new writers and then waits for everything
+// already accepted to be delivered.
+//
+// The two halves are inseparable. Flushing a snapshot alone would leave a
+// window: the SSH server keeps serving while the flush runs, so a guest
+// attaching after the snapshot has its replay queued into a sink this call will
+// never flush, and teardown closes it before delivery. Quiescing under writeMu,
+// the same lock Append takes, leaves no such window — an attach is either
+// inside the snapshot or refused.
+//
+// Members that do not buffer are skipped: a synchronous writer is delivered by
+// definition. A sink that has already failed flushes to nil, because a guest
+// that is already gone is not a shutdown error.
+func (t *MultiWriter) Shutdown(ctx context.Context) error {
+	t.writeMu.Lock()
+	t.closed = true
+	t.membersMu.Lock()
+	writers := make([]io.Writer, len(t.writers))
+	copy(writers, t.writers)
+	t.membersMu.Unlock()
+	t.writeMu.Unlock()
+
+	var (
+		wg   sync.WaitGroup
+		errs = make([]error, len(writers))
+	)
+	for i, w := range writers {
+		f, ok := w.(Flusher)
+		if !ok {
+			continue
+		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs[i] = f.Flush(ctx)
+		}()
+	}
+	wg.Wait()
+
+	return errors.Join(errs...)
 }

--- a/io/writer.go
+++ b/io/writer.go
@@ -19,8 +19,14 @@ func (c *buffer) Append(p []byte) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	// remove first element if queue is full
-	if len(c.queue) >= c.size {
+	// A buffer built with a non-positive size keeps nothing; without this the
+	// trim below slices an empty queue and panics.
+	if c.size <= 0 {
+		return
+	}
+
+	// remove leading elements until there is room
+	for len(c.queue) >= c.size {
 		c.queue = c.queue[1:]
 	}
 
@@ -30,18 +36,14 @@ func (c *buffer) Append(p []byte) {
 	c.queue = append(c.queue, pp)
 }
 
-func (c *buffer) Size() int {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	return len(c.queue)
-}
-
 func (c *buffer) Data() [][]byte {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	result := make([][]byte, len(c.queue))
+	// Length, not capacity, was the bug: this returned len(queue) nil entries
+	// followed by the real ones, so every newly attached writer was handed that
+	// many zero-length writes before its replay.
+	result := make([][]byte, 0, len(c.queue))
 	return append(result, c.queue...)
 }
 
@@ -73,6 +75,15 @@ type MultiWriter struct {
 	buffer *buffer
 }
 
+// Append attaches writers, handing each the replay buffer first so it starts
+// from recent output rather than mid-screen.
+//
+// Both steps happen under writeMu, the fan-out lock, so attaching is atomic
+// with respect to a Write: a joining writer gets the replay and every write
+// after it, never a write that is also in its replay and never a gap between
+// them. Holding the fan-out lock here is only safe because attached guest
+// writers no longer block on I/O; under the old design it would have
+// reintroduced the deadlock #523 removed.
 func (t *MultiWriter) Append(writers ...io.Writer) error {
 	// Reject anything Remove could not later take back out, before it is
 	// attached and before it is written to.
@@ -82,14 +93,13 @@ func (t *MultiWriter) Append(writers ...io.Writer) error {
 		}
 	}
 
-	// write last buffer to new writers
-	if t.buffer.Size() > 0 {
-		for _, w := range writers {
-			for _, d := range t.buffer.Data() {
-				_, err := w.Write(d)
-				if err != nil {
-					return err
-				}
+	t.writeMu.Lock()
+	defer t.writeMu.Unlock()
+
+	for _, w := range writers {
+		for _, d := range t.buffer.Data() {
+			if _, err := w.Write(d); err != nil {
+				return err
 			}
 		}
 	}
@@ -169,10 +179,12 @@ func (t *MultiWriter) Remove(writers ...io.Writer) {
 // A writer removed between the snapshot and the write still receives this one
 // write. That is harmless: it is a session on its way out.
 //
-// Still outstanding: the writes are serial, so a guest that has stopped reading
-// holds up the fan-out for everyone until its write returns. Fixing that needs
-// per-writer buffering, so that a guest which cannot keep up is dropped rather
-// than allowed to slow the session down. Tracked in owenthereal/upterm#524.
+// Writers that buffer are what keep this serial loop honest: each attached
+// guest is an AsyncWriter, so its Write is a copy and a signal rather than SSH
+// I/O, and a guest that cannot keep up overflows and is dropped instead of
+// pacing everyone else. The host's own stdout is attached unwrapped and so is
+// written inline here, which is the one place back-pressure belongs: the pty
+// should not run ahead of the terminal that owns it.
 func (t *MultiWriter) Write(p []byte) (int, error) {
 	t.writeMu.Lock()
 	defer t.writeMu.Unlock()

--- a/io/writer_test.go
+++ b/io/writer_test.go
@@ -252,3 +252,65 @@ func TestMultiWriterRemoveFirstWriter(t *testing.T) {
 	assert.Empty(t, first.String(), "the writer at index 0 should have been removed")
 	assert.Equal(t, "hello", second.String())
 }
+
+// A writer joining a live session must see a contiguous stream: no byte
+// delivered twice, none missing. Append replays the buffer and joins the member
+// list as two separate steps today, with no lock spanning them, so a concurrent
+// Write lands either side of the gap.
+func TestMultiWriterAppendIsAtomicWithTheFanOut(t *testing.T) {
+	for attempt := range 50 {
+		w := NewMultiWriter(5)
+
+		produced := make(chan string, 1)
+		stop := make(chan struct{})
+		go func() {
+			var sent []byte
+			for i := 0; ; i++ {
+				select {
+				case <-stop:
+					produced <- string(sent)
+					return
+				default:
+				}
+				p := []byte{byte('a' + i%26)}
+				sent = append(sent, p...)
+				_, _ = w.Write(p)
+			}
+		}()
+
+		time.Sleep(time.Duration(attempt%5) * time.Millisecond)
+		var joined bytes.Buffer
+		require.NoError(t, w.Append(&joined))
+		time.Sleep(time.Millisecond)
+		close(stop)
+		all := <-produced
+
+		got := joined.String()
+		require.NotEmpty(t, got, "a joining writer should receive the replay buffer")
+		require.Contains(t, all, got,
+			"attempt %d: a joining writer saw bytes that were duplicated or skipped", attempt)
+	}
+}
+
+// Data built its result with make([][]byte, len(queue)) and then appended, so it
+// returned N nil entries before the N real ones and every newly attached writer
+// received N zero-length writes.
+func TestMultiWriterReplayHasNoEmptyWrites(t *testing.T) {
+	w := NewMultiWriter(3)
+	_, _ = w.Write([]byte("one"))
+	_, _ = w.Write([]byte("two"))
+
+	var rec recordingWriter
+	require.NoError(t, w.Append(&rec))
+
+	require.Equal(t, []int{3, 3}, rec.writeSizes(), "replay must not emit empty writes")
+	require.Equal(t, "onetwo", string(rec.bytes()))
+}
+
+func TestMultiWriterZeroSizedReplayBufferDoesNotPanic(t *testing.T) {
+	w := NewMultiWriter(0)
+	var rec recordingWriter
+	require.NoError(t, w.Append(&rec))
+	require.NotPanics(t, func() { _, _ = w.Write([]byte("output")) })
+	require.Equal(t, "output", string(rec.bytes()))
+}

--- a/io/writer_test.go
+++ b/io/writer_test.go
@@ -430,3 +430,80 @@ func TestMultiWriterShutdownGivesUpOnAStuckSink(t *testing.T) {
 	defer cancel()
 	require.ErrorIs(t, w.Shutdown(ctx), context.DeadlineExceeded)
 }
+
+// The issue, end to end at the fan-out level: one guest that has stopped
+// reading must not stall the host's terminal or any other guest, and must
+// itself be dropped rather than tolerated.
+//
+// Before per-guest buffering, the stuck writer held the serial fan-out inside
+// its Write and nothing after it in the slice received anything at all.
+func TestMultiWriterSlowGuestDoesNotStallTheSession(t *testing.T) {
+	const sinkCap = 4 << 10
+
+	var hostStdout recordingWriter // attached unwrapped, as the host's own is
+
+	healthyOut := &recordingWriter{}
+	healthy := NewAsyncWriter(healthyOut, DefaultGuestBufferSize, nil)
+	defer func() { _ = healthy.Close() }()
+
+	stuckOut := newGateWriter()
+	defer close(stuckOut.release)
+	dropped := make(chan error, 1)
+	stuck := NewAsyncWriter(stuckOut, sinkCap, func(err error) { dropped <- err })
+	defer func() { _ = stuck.Close() }()
+
+	w := NewMultiWriter(5)
+	require.NoError(t, w.Append(&hostStdout))
+	require.NoError(t, w.Append(stuck))
+	require.NoError(t, w.Append(healthy))
+
+	// Fill the stuck guest's buffer and keep going, as a `cat` of a large file
+	// would. Run on its own goroutine and race it against a timeout, the same
+	// way TestAsyncWriterWriteDoesNotBlockOnStuckWriter does: nothing here
+	// bounds an individual w.Write call, so a regression that reintroduces
+	// blocking would otherwise hang this goroutine until the package's
+	// -timeout killed the whole binary instead of failing just this test.
+	line := bytes.Repeat([]byte("x"), 1<<10)
+	var (
+		want     []byte
+		writeErr error
+		writeN   int
+	)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for range 64 {
+			want = append(want, line...)
+			writeN, writeErr = w.Write(line)
+			if writeErr != nil || writeN != len(line) {
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the fan-out blocked on a stuck guest")
+	}
+	// require.FailNow, which these call on failure, must only run on the test
+	// goroutine, so the checks are made here rather than inside the goroutine
+	// above.
+	require.NoError(t, writeErr, "the fan-out never reports a guest's failure")
+	require.Equal(t, len(line), writeN)
+
+	select {
+	case err := <-dropped:
+		require.ErrorIs(t, err, ErrOverflow)
+	case <-time.After(5 * time.Second):
+		t.Fatal("the stuck guest was never dropped")
+	}
+
+	require.Equal(t, want, hostStdout.bytes(), "the host's terminal must see everything")
+	require.Eventually(t, func() bool { return bytes.Equal(healthyOut.bytes(), want) },
+		5*time.Second, time.Millisecond, "a healthy guest must see everything")
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	require.NoError(t, w.Shutdown(ctx), "a dropped guest must not fail shutdown")
+}

--- a/io/writer_test.go
+++ b/io/writer_test.go
@@ -2,6 +2,7 @@ package io
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"sync"
@@ -313,4 +314,119 @@ func TestMultiWriterZeroSizedReplayBufferDoesNotPanic(t *testing.T) {
 	require.NoError(t, w.Append(&rec))
 	require.NotPanics(t, func() { _, _ = w.Write([]byte("output")) })
 	require.Equal(t, "output", string(rec.bytes()))
+}
+
+func TestMultiWriterShutdownFlushesAsyncMembers(t *testing.T) {
+	gate := newGateWriter()
+	sink := NewAsyncWriter(gate, DefaultGuestBufferSize, nil)
+	defer func() { _ = sink.Close() }()
+
+	w := NewMultiWriter(5)
+	require.NoError(t, w.Append(sink))
+	_, _ = w.Write([]byte("last line of the session"))
+	<-gate.entered
+
+	shutdown := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		shutdown <- w.Shutdown(ctx)
+	}()
+
+	select {
+	case <-shutdown:
+		t.Fatal("Shutdown returned before the sink drained")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(gate.release)
+	select {
+	case err := <-shutdown:
+		require.NoError(t, err)
+		require.Equal(t, "last line of the session", string(gate.bytes()))
+	case <-time.After(5 * time.Second):
+		t.Fatal("Shutdown never returned")
+	}
+}
+
+// The SSH server keeps serving while the flush runs. Without the quiesce, a
+// guest attaching after the snapshot has its replay queued into a sink nobody
+// will flush, and teardown closes it before delivery: an empty screen and a
+// disconnect.
+func TestMultiWriterShutdownRefusesLaterAppends(t *testing.T) {
+	w := NewMultiWriter(5)
+	var before bytes.Buffer
+	require.NoError(t, w.Append(&before))
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	require.NoError(t, w.Shutdown(ctx))
+
+	var after bytes.Buffer
+	require.ErrorIs(t, w.Append(&after), ErrClosed)
+}
+
+// The sequential case above proves the door is shut; this proves there is no
+// gap in front of it. An attach racing the quiesce must land on one side or
+// the other — attached and therefore flushed, or refused — never attached to a
+// snapshot that has already been taken, which is the outcome that leaves a
+// guest with a queued replay nobody will deliver.
+func TestMultiWriterAppendRacingShutdownHasOnlyTwoOutcomes(t *testing.T) {
+	for attempt := range 50 {
+		w := NewMultiWriter(5)
+		_, _ = w.Write([]byte("output"))
+
+		var out recordingWriter
+		sink := NewAsyncWriter(&out, DefaultGuestBufferSize, nil)
+
+		var (
+			wg        sync.WaitGroup
+			appendErr error
+		)
+		wg.Add(2)
+		go func() { defer wg.Done(); appendErr = w.Append(sink) }()
+		go func() {
+			defer wg.Done()
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			_ = w.Shutdown(ctx)
+		}()
+		wg.Wait()
+
+		if appendErr == nil {
+			require.Equal(t, "output", string(out.bytes()),
+				"attempt %d: an attach that succeeded must have been flushed", attempt)
+		} else {
+			require.ErrorIs(t, appendErr, ErrClosed, "attempt %d", attempt)
+			require.Empty(t, out.bytes(), "attempt %d: a refused attach must receive nothing", attempt)
+		}
+		_ = sink.Close()
+	}
+}
+
+func TestMultiWriterShutdownIgnoresPlainWriters(t *testing.T) {
+	w := NewMultiWriter(5)
+	var plain bytes.Buffer
+	require.NoError(t, w.Append(&plain))
+	_, _ = w.Write([]byte("output"))
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	require.NoError(t, w.Shutdown(ctx), "a synchronous writer is delivered by definition")
+}
+
+func TestMultiWriterShutdownGivesUpOnAStuckSink(t *testing.T) {
+	gate := newGateWriter()
+	defer close(gate.release)
+	sink := NewAsyncWriter(gate, DefaultGuestBufferSize, nil)
+	defer func() { _ = sink.Close() }()
+
+	w := NewMultiWriter(5)
+	require.NoError(t, w.Append(sink))
+	_, _ = w.Write([]byte("never delivered"))
+	<-gate.entered
+
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+	require.ErrorIs(t, w.Shutdown(ctx), context.DeadlineExceeded)
 }

--- a/server/sshforward.go
+++ b/server/sshforward.go
@@ -77,9 +77,15 @@ const (
 const (
 	// sshForwardChannelDrainTimeout bounds how long a direction whose source
 	// has closed may stay blocked writing to a destination that has stopped
-	// reading. It matches sshForwardDrainTimeout and carries the same
-	// trade-off: a consumer stalled beyond the grace can lose bytes it had not
-	// yet received.
+	// reading, on a connection that is otherwise live. It carries the same
+	// trade-off as sshForwardDrainTimeout: a consumer stalled beyond the grace
+	// can lose bytes it had not yet received.
+	//
+	// The two are equal by coincidence of judgement, not by design, and nothing
+	// should be read into the match. They never apply at once —
+	// abortStalledDirection stands down as soon as the connection starts
+	// draining — and that separation is deliberate: when both were armed on one
+	// stall, which fired first decided which error the shutdown reported.
 	//
 	// It bounds total drain time, not lack of progress: a destination draining
 	// steadily but slowly is treated exactly like one that stopped, because the
@@ -111,10 +117,12 @@ var errSSHChannelDrainStalled = errors.New("ssh: channel drain stalled after sou
 func forwardSSH(ctx context.Context, downstream, upstream sshPeer, scope sshAbortScope) error {
 	ctx, cancel := context.WithCancelCause(ctx)
 	defer cancel(nil)
+	draining := make(chan struct{})
 	forwarder := sshForwarder{
 		ctx:          ctx,
 		cancel:       cancel,
 		scope:        scope,
+		draining:     draining,
 		drainTimeout: sshForwardChannelDrainTimeout,
 		abortGrace:   sshForwardChannelAbortGrace,
 	}
@@ -124,7 +132,6 @@ func forwardSSH(ctx context.Context, downstream, upstream sshPeer, scope sshAbor
 		err   error
 	}
 	exited := make(chan peerExit, 2)
-	draining := make(chan struct{})
 	channelsDone := [2]chan struct{}{make(chan struct{}), make(chan struct{})}
 	requestsDone := [2]chan struct{}{make(chan struct{}), make(chan struct{})}
 	peers := []sshPeer{downstream, upstream}
@@ -187,6 +194,11 @@ type sshForwarder struct {
 	ctx    context.Context
 	cancel context.CancelCauseFunc
 	scope  sshAbortScope
+
+	// draining closes when the connection starts shutting down, which is what
+	// hands the stalled-channel bound over to forwardSSH. Nil in tests that
+	// exercise a single direction, where nothing else owns that bound.
+	draining <-chan struct{}
 
 	// Fields rather than direct reads of the constants above, so tests can run
 	// the watchdog on a timescale that does not dominate the suite.
@@ -390,15 +402,26 @@ func (f sshForwarder) channelDirection(destination, source *sshForwardChannel, r
 // keeps active non-nil, so its loop does not even reach its own exit condition
 // while completed never fires, and past the loop its deferred wait for the
 // sender would hold it anyway. Neither barrier lifts until the write does.
+//
+// It stands down the moment the connection itself begins draining, because
+// from there forwardSSH's own bound owns the stall: it allows
+// sshForwardDrainTimeout for the channel buffers and then closes both
+// transports, which releases a blocked write more thoroughly than closing one
+// channel does. Two bounds on the same stall would otherwise race — they are
+// armed within moments of each other and, before this, ran on identical
+// timeouts — and the winner decides which error the shutdown reports. The
+// transport's is the one callers are contracted to see.
 func (f sshForwarder) abortStalledDirection(destination ssh.Channel, sourceClosed, finished <-chan struct{}) {
 	select {
 	case <-finished:
 		return
 	case <-f.ctx.Done():
 		return
+	case <-f.draining:
+		return
 	case <-sourceClosed:
 	}
-	if waitAny(finished, f.ctx.Done(), f.drainTimeout) {
+	if f.settledWithin(finished, f.drainTimeout) {
 		return
 	}
 	// In its own goroutine, for the reason above. A write blocked on an
@@ -406,7 +429,7 @@ func (f sshForwarder) abortStalledDirection(destination ssh.Channel, sourceClose
 	// enough whenever the peer is still reading its socket: it answers the
 	// CLOSE, and x/crypto's channel teardown fails the pending write.
 	go func() { _ = destination.Close() }()
-	if waitAny(finished, f.ctx.Done(), f.abortGrace) {
+	if f.settledWithin(finished, f.abortGrace) {
 		return
 	}
 	if f.scope == abortConnection {
@@ -414,14 +437,18 @@ func (f sshForwarder) abortStalledDirection(destination ssh.Channel, sourceClose
 	}
 }
 
-// waitAny reports whether done or cancelled fired before timeout elapsed.
-func waitAny(done, cancelled <-chan struct{}, timeout time.Duration) bool {
+// settledWithin reports whether this direction finished, the connection began
+// draining, or the context was cancelled before timeout elapsed — the three
+// ways the watchdog stops being the thing that has to act.
+func (f sshForwarder) settledWithin(finished <-chan struct{}, timeout time.Duration) bool {
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()
 	select {
-	case <-done:
+	case <-finished:
 		return true
-	case <-cancelled:
+	case <-f.draining:
+		return true
+	case <-f.ctx.Done():
 		return true
 	case <-timer.C:
 		return false

--- a/server/sshforward.go
+++ b/server/sshforward.go
@@ -78,7 +78,7 @@ func forwardSSH(ctx context.Context, downstream, upstream sshPeer) error {
 			// not hold up drain completion on that reply, but still drain all channel
 			// buffers before closing the destination transport to release its sender.
 			// Zero grace: finished only signals drain completion, it writes nothing.
-			forwarder.requests(destination.conn, source.requests, finished, 0, nil)
+			forwarder.requests(destination.conn, source.requests, nil, finished, 0, nil)
 		})
 	}
 	var err error
@@ -286,7 +286,7 @@ type sshForwardChannel struct {
 func (f sshForwarder) channelDirection(destination, source *sshForwardChannel, requests <-chan *ssh.Request) {
 	var streams sync.WaitGroup
 	streams.Go(func() { copySSHChannel(destination, source) })
-	f.requests(sshChannelRequestSender{destination}, requests, func() { _ = destination.Close() }, sshRequestAbortGrace, &source.replies)
+	f.requests(sshChannelRequestSender{destination}, requests, nil, func() { _ = destination.Close() }, sshRequestAbortGrace, &source.replies)
 	streams.Wait()
 	// The source may send success and CLOSE back-to-back. Its reply worker
 	// must deliver that success before this direction closes the destination.
@@ -356,7 +356,17 @@ type sshRequestJob struct {
 // after sshRequestAbortGrace: for channels it closes the destination channel,
 // for globals it waives waiting for the reply during transport drain. Pass a
 // zero grace where abortPending writes nothing to the wire.
-func (f sshForwarder) requests(destination sshRequestSender, incoming <-chan *ssh.Request, abortPending func(), grace time.Duration, replies *sync.Mutex) {
+//
+// sourceClosed, which may be nil, fires once when incoming closes: the point at
+// which the source can send nothing further. It is distinct from abortPending,
+// which fires only when a reply was outstanding at that moment, and it is
+// reported from the ingress loop rather than on return, because the serial
+// sender may still be blocked writing to a destination that has stopped
+// reading. A caller that needs to bound such a destination cannot wait for this
+// function to return. It runs synchronously on the ingress loop's goroutine, so
+// a slow sourceClosed delays further dispatch and cancellation handling until
+// it returns.
+func (f sshForwarder) requests(destination sshRequestSender, incoming <-chan *ssh.Request, sourceClosed func(), abortPending func(), grace time.Duration, replies *sync.Mutex) {
 	jobs := make(chan sshRequestJob)
 	completed := make(chan struct{})
 	senderDone := make(chan struct{})
@@ -414,6 +424,9 @@ func (f sshForwarder) requests(destination sshRequestSender, incoming <-chan *ss
 		case request, ok := <-incoming:
 			if !ok {
 				incoming = nil
+				if sourceClosed != nil {
+					sourceClosed()
+				}
 				// The reply this send is waiting on can no longer be delivered.
 				// Let the destination answer anyway if it is merely slow; the
 				// same wait puts the request write safely ahead of the CLOSE

--- a/server/sshforward.go
+++ b/server/sshforward.go
@@ -49,14 +49,75 @@ type sshPeer struct {
 // explicit cancellation, shutdown and queue overflow always interrupt it.
 const sshForwardDrainTimeout = 5 * time.Second
 
+// A stalled channel whose source has closed is bounded, but how far the bound
+// may escalate depends on whose connection it is.
+type sshAbortScope int
+
+const (
+	// abortChannel closes the stalled channel and stops there. This is the
+	// scope for a host connection, whose transport carries the reverse tunnel
+	// every guest's traffic rides: tearing it down over one stalled channel
+	// would end the session for everyone attached.
+	abortChannel sshAbortScope = iota
+
+	// abortConnection may additionally cancel the forwarder, closing both
+	// transports. This is the scope for a guest connection, which is that one
+	// guest's: forwardSSH runs per accepted downstream connection with its own
+	// dialed upstream, so cancelling ends that guest and nothing else.
+	//
+	// Nothing else, but not nothing: it ends every channel on that connection,
+	// not just the stalled one, and ends them abruptly. The escalation fires
+	// while both transports are still live, so closedPeer stays -1 above and
+	// forwardSSH skips its drain loop entirely — the other channels lose
+	// whatever SSH had buffered for them, with no grace at all. Weigh that
+	// against sshForwardChannelDrainTimeout before shortening it.
+	abortConnection
+)
+
+const (
+	// sshForwardChannelDrainTimeout bounds how long a direction whose source
+	// has closed may stay blocked writing to a destination that has stopped
+	// reading. It matches sshForwardDrainTimeout and carries the same
+	// trade-off: a consumer stalled beyond the grace can lose bytes it had not
+	// yet received.
+	//
+	// It bounds total drain time, not lack of progress: a destination draining
+	// steadily but slowly is treated exactly like one that stopped, because the
+	// copy below is a plain io.Copy and reports nothing until it finishes. So
+	// this is also the deadline by which a merely slow consumer is declared
+	// stalled — five seconds of real drain is the budget, not five seconds of
+	// silence.
+	sshForwardChannelDrainTimeout = 5 * time.Second
+
+	// sshForwardChannelAbortGrace is how long the CLOSE sent after that has to
+	// take effect. A peer that is reading its socket at all answers a CLOSE in
+	// microseconds; one that does not is not reading the socket either, and
+	// only transport teardown can release the write.
+	//
+	// What follows the grace is the expensive step, and only on a guest
+	// connection: abortConnection cancels the forwarder, which takes down every
+	// other channel on that connection without draining any of them. The grace
+	// is short because a peer that has not answered by now will not, not
+	// because the next step is cheap.
+	sshForwardChannelAbortGrace = time.Second
+)
+
+var errSSHChannelDrainStalled = errors.New("ssh: channel drain stalled after source close")
+
 // forwardSSH owns both authenticated connections and joins all workers before
 // returning. Ordinary transport completion first drains received channel data
 // and request tails toward the surviving peer; forced cancellation closes both
 // transports immediately to release blocked opens, requests and writes.
-func forwardSSH(ctx context.Context, downstream, upstream sshPeer) error {
+func forwardSSH(ctx context.Context, downstream, upstream sshPeer, scope sshAbortScope) error {
 	ctx, cancel := context.WithCancelCause(ctx)
 	defer cancel(nil)
-	forwarder := sshForwarder{ctx: ctx, cancel: cancel}
+	forwarder := sshForwarder{
+		ctx:          ctx,
+		cancel:       cancel,
+		scope:        scope,
+		drainTimeout: sshForwardChannelDrainTimeout,
+		abortGrace:   sshForwardChannelAbortGrace,
+	}
 	var workers sync.WaitGroup
 	type peerExit struct {
 		index int
@@ -125,6 +186,12 @@ func forwardSSH(ctx context.Context, downstream, upstream sshPeer) error {
 type sshForwarder struct {
 	ctx    context.Context
 	cancel context.CancelCauseFunc
+	scope  sshAbortScope
+
+	// Fields rather than direct reads of the constants above, so tests can run
+	// the watchdog on a timescale that does not dominate the suite.
+	drainTimeout time.Duration
+	abortGrace   time.Duration
 }
 
 // A peer can pipeline channel opens without waiting for confirmation, and each
@@ -261,9 +328,12 @@ type sshForwardChannel struct {
 //     serializes channel packets and refuses writes once CLOSE has gone out,
 //     so a peer reading until CHANNEL_CLOSE is not truncated here. The aborts
 //     are the exception: abortPending closes destination from inside requests,
-//     before streams.Wait(), and cancellation, request-queue overflow and
-//     sshForwardDrainTimeout close both transports outright. Each of those can
-//     cut a Write that has not returned, and copySSHChannel discards the error.
+//     before streams.Wait(); abortStalledDirection closes it from a watchdog
+//     once the source has closed and the copy has not drained within
+//     sshForwardChannelDrainTimeout; and cancellation, request-queue overflow
+//     and sshForwardDrainTimeout close both transports outright. Each of those
+//     can cut a Write that has not returned, and copySSHChannel discards the
+//     error.
 //   - EOF before CLOSE, and half-close survives. See copySSHChannel.
 //
 // It does not preserve the relative order of ordinary data, extended data and
@@ -283,16 +353,79 @@ type sshForwardChannel struct {
 // output and status after stdin EOF. Treat either endpoint's CLOSE
 // symmetrically so a caller can close one channel without leaving its peer
 // open for the connection's lifetime.
+//
+// That symmetry is not enough on its own when the destination has stopped
+// reading: the copy below stays blocked in its Write, so the close at the end
+// is never reached and the pair is stranded for the connection's lifetime.
+// abortStalledDirection bounds it.
 func (f sshForwarder) channelDirection(destination, source *sshForwardChannel, requests <-chan *ssh.Request) {
+	finished := make(chan struct{})
+	defer close(finished)
+	sourceClosed := make(chan struct{})
+	go f.abortStalledDirection(destination, sourceClosed, finished)
+
 	var streams sync.WaitGroup
 	streams.Go(func() { copySSHChannel(destination, source) })
-	f.requests(sshChannelRequestSender{destination}, requests, nil, func() { _ = destination.Close() }, sshRequestAbortGrace, &source.replies)
+	f.requests(sshChannelRequestSender{destination}, requests,
+		sync.OnceFunc(func() { close(sourceClosed) }),
+		func() { _ = destination.Close() }, sshRequestAbortGrace, &source.replies)
 	streams.Wait()
 	// The source may send success and CLOSE back-to-back. Its reply worker
 	// must deliver that success before this direction closes the destination.
 	destination.replies.Lock()
 	defer destination.replies.Unlock()
 	_ = destination.Close()
+}
+
+// abortStalledDirection releases a direction whose source has closed but whose
+// destination has stopped accepting bytes.
+//
+// It is a watchdog rather than a step in the teardown because every step of
+// that teardown is itself a transport write a stalled peer can block. Close
+// marshals CHANNEL_CLOSE and calls writePacket, which takes the channel's write
+// mutex and writes to the transport — the same mutex a blocked Write already
+// holds — so a sequential abort would never reach its own timer in the case it
+// exists for. requests has the same problem one step earlier, behind two
+// barriers rather than one: a request still dispatched to that blocked sender
+// keeps active non-nil, so its loop does not even reach its own exit condition
+// while completed never fires, and past the loop its deferred wait for the
+// sender would hold it anyway. Neither barrier lifts until the write does.
+func (f sshForwarder) abortStalledDirection(destination ssh.Channel, sourceClosed, finished <-chan struct{}) {
+	select {
+	case <-finished:
+		return
+	case <-f.ctx.Done():
+		return
+	case <-sourceClosed:
+	}
+	if waitAny(finished, f.ctx.Done(), f.drainTimeout) {
+		return
+	}
+	// In its own goroutine, for the reason above. A write blocked on an
+	// exhausted window does not hold the channel's write mutex, so this is
+	// enough whenever the peer is still reading its socket: it answers the
+	// CLOSE, and x/crypto's channel teardown fails the pending write.
+	go func() { _ = destination.Close() }()
+	if waitAny(finished, f.ctx.Done(), f.abortGrace) {
+		return
+	}
+	if f.scope == abortConnection {
+		f.cancel(errSSHChannelDrainStalled)
+	}
+}
+
+// waitAny reports whether done or cancelled fired before timeout elapsed.
+func waitAny(done, cancelled <-chan struct{}, timeout time.Duration) bool {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-done:
+		return true
+	case <-cancelled:
+		return true
+	case <-timer.C:
+		return false
+	}
 }
 
 // copySSHChannel copies ordinary data and extended data concurrently, so byte

--- a/server/sshforward_stockclient_test.go
+++ b/server/sshforward_stockclient_test.go
@@ -100,7 +100,8 @@ func forwardTestStockClientHost(t *testing.T) (string, sshPeer) {
 			_ = conn.Close()
 			return
 		}
-		_ = forwardSSH(ctx, sshPeer{serverConn, channels, requests}, upstream)
+		// A stock OpenSSH client is a guest, so its connection is the abort unit.
+		_ = forwardSSH(ctx, sshPeer{serverConn, channels, requests}, upstream, abortConnection)
 	}()
 
 	return listener.Addr().String(), host

--- a/server/sshforward_test.go
+++ b/server/sshforward_test.go
@@ -17,6 +17,7 @@ import (
 	"testing/synctest"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -60,6 +61,12 @@ func forwardTestPair(t *testing.T, serverConfig *ssh.ServerConfig, clientConfig 
 			accepted <- result{err: err}
 			return
 		}
+		// The deadline bounds the handshake, not the test. Left armed it
+		// expires mid-test on anything that runs longer, breaking the transport
+		// in a way that reads as the failure the test was looking for. Clearing
+		// it here is what sshstock.go does after its own handshake; the tests
+		// carry their own explicit bounds.
+		_ = conn.SetDeadline(time.Time{})
 		accepted <- result{peer: sshPeer{sc, channels, requests}}
 	}()
 	conn, err := net.Dial("tcp", listener.Addr().String())
@@ -71,6 +78,7 @@ func forwardTestPair(t *testing.T, serverConfig *ssh.ServerConfig, clientConfig 
 	if err != nil {
 		t.Fatal(err)
 	}
+	_ = conn.SetDeadline(time.Time{})
 	server := <-accepted
 	if server.err != nil {
 		t.Fatal(server.err)
@@ -97,7 +105,7 @@ func forwardTestProxy(t *testing.T) (sshPeer, sshPeer, context.CancelFunc, <-cha
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	stopped := make(chan struct{})
-	go func() { defer close(stopped); done <- forwardSSH(ctx, downstream, upstream) }()
+	go func() { defer close(stopped); done <- forwardSSH(ctx, downstream, upstream, abortConnection) }()
 	t.Cleanup(func() {
 		cancel()
 		select {
@@ -1157,7 +1165,7 @@ func TestSSHForwardSuccessReplyBeforePeerClose(t *testing.T) {
 			}
 			ctx, cancel := context.WithCancel(context.Background())
 			done := make(chan error, 1)
-			go func() { done <- forwardSSH(ctx, downstream, upstream) }()
+			go func() { done <- forwardSSH(ctx, downstream, upstream, abortConnection) }()
 			t.Cleanup(func() { cancel(); _ = forwardTestReceive(t, done) })
 			a, ar, b, br := forwardTestChannel(t, origin, destination)
 			type response struct {
@@ -1429,4 +1437,380 @@ type senderFunc func(string, bool, []byte) (bool, []byte, error)
 
 func (s senderFunc) SendRequest(name string, wantReply bool, payload []byte) (bool, []byte, error) {
 	return s(name, wantReply, payload)
+}
+
+// channelGate blocks whichever of a channel's methods the test chooses, the way
+// x/crypto's channel blocks when the window is exhausted (Write) or the socket
+// is full (any of them, since each is a transport write under the channel's
+// write mutex). A nil gate channel means that method is not blocked.
+type channelGate struct {
+	write   chan struct{}
+	request chan struct{}
+	close   chan struct{}
+
+	closed    chan struct{}
+	closeOnce sync.Once
+}
+
+func newChannelGate() *channelGate {
+	return &channelGate{closed: make(chan struct{})}
+}
+
+// releaseAll unblocks every gated method, so a test can require that the code
+// under test actually unwinds rather than merely that it fired a callback.
+func (g *channelGate) releaseAll() {
+	for _, c := range []chan struct{}{g.write, g.request, g.close} {
+		if c != nil {
+			close(c)
+		}
+	}
+}
+
+type gatedChannel struct {
+	ssh.Channel
+	gate *channelGate
+}
+
+func (g gatedChannel) Write(p []byte) (int, error) {
+	if g.gate.write != nil {
+		<-g.gate.write
+	}
+	return g.Channel.Write(p)
+}
+
+func (g gatedChannel) SendRequest(name string, wantReply bool, payload []byte) (bool, error) {
+	if g.gate.request != nil {
+		<-g.gate.request
+	}
+	return g.Channel.SendRequest(name, wantReply, payload)
+}
+
+func (g gatedChannel) Close() error {
+	if g.gate.close != nil {
+		<-g.gate.close
+	}
+	g.gate.closeOnce.Do(func() { close(g.gate.closed) })
+	return g.Channel.Close()
+}
+
+// openTestChannel opens a "session" channel on a peer's connection and discards
+// the requests that come back on it. Something on the far side has to be
+// accepting concurrently: OpenChannel blocks until the peer answers.
+func openTestChannel(t *testing.T, peer sshPeer) ssh.Channel {
+	t.Helper()
+	channel, requests, err := peer.conn.OpenChannel("session", nil)
+	require.NoError(t, err)
+	go ssh.DiscardRequests(requests)
+	t.Cleanup(func() { _ = channel.Close() })
+	return channel
+}
+
+// acceptTestChannel accepts the next channel offered to a peer and discards its
+// requests, reporting nil once the peer stops offering any. It reports rather
+// than fails because its callers run it on goroutines of their own, where the
+// testing package forbids FailNow.
+func acceptTestChannel(peer sshPeer) ssh.Channel {
+	incoming, ok := <-peer.channels
+	if !ok {
+		return nil
+	}
+	channel, requests, err := incoming.Accept()
+	if err != nil {
+		return nil
+	}
+	go ssh.DiscardRequests(requests)
+	return channel
+}
+
+// forwardTestDirection builds one direction the way the forwarder really sees
+// it: a source on one connection and a destination on another, never two ends
+// of the same channel.
+//
+// Three things here are not optional. OpenChannel blocks until the peer
+// accepts, so the accept has to run concurrently or the fixture deadlocks
+// against itself. Source and destination must be independent connections, or
+// the copy feeds forwarded bytes straight back into the source. And the source
+// end is closed by its own peer, because the returned request channel is a
+// plain Go channel — closing it signals source closure to channelDirection but
+// produces no EOF on a real stream.
+func forwardTestDirection(t *testing.T, gate *channelGate) (destination, source *sshForwardChannel, requests chan *ssh.Request, closeSource func()) {
+	t.Helper()
+
+	open := func(peerA, peerB sshPeer) (near, far ssh.Channel) {
+		t.Helper()
+		accepted := make(chan ssh.Channel, 1)
+		go func() { accepted <- acceptTestChannel(peerB) }()
+		near = openTestChannel(t, peerA)
+		far = <-accepted
+		require.NotNil(t, far, "the peer failed to accept the channel")
+		return near, far
+	}
+
+	// The producer connection: its far end is what channelDirection reads.
+	producerNear, producerFar := open(forwardTestPair(t, nil, nil))
+	// The consumer connection: its far end is what channelDirection writes to,
+	// gated so the test can stall it.
+	consumerNear, _ := open(forwardTestPair(t, nil, nil))
+
+	// Give the source something to forward, so the copy is inside the
+	// destination's Write by the time the source closes.
+	_, err := producerNear.Write([]byte("shell output"))
+	require.NoError(t, err)
+
+	return &sshForwardChannel{Channel: gatedChannel{Channel: consumerNear, gate: gate}},
+		&sshForwardChannel{Channel: producerFar},
+		make(chan *ssh.Request),
+		func() { _ = producerNear.Close() }
+}
+
+// newTestForwarder builds a forwarder whose cancel is observable and whose
+// timers are short enough to run in a test.
+func newTestForwarder(t *testing.T, scope sshAbortScope, cancelled chan<- error) sshForwarder {
+	t.Helper()
+	ctx, cancel := context.WithCancelCause(context.Background())
+	t.Cleanup(func() { cancel(nil) })
+	return sshForwarder{
+		ctx:          ctx,
+		scope:        scope,
+		drainTimeout: 100 * time.Millisecond,
+		abortGrace:   50 * time.Millisecond,
+		cancel: func(err error) {
+			cancel(err)
+			select {
+			case cancelled <- err:
+			default:
+			}
+		},
+	}
+}
+
+func TestChannelDirectionAbortsAStalledDestination(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		setup func(*channelGate)
+	}{
+		// The plain case: the guest stopped reading, so the window is
+		// exhausted and the copy is stuck in Write.
+		{"write blocked", func(g *channelGate) { g.write = make(chan struct{}) }},
+		// Close blocked too, which is what a full socket looks like: Close is a
+		// transport write under the same mutex the blocked Write holds. A
+		// sequential abort could never reach its own timer here.
+		{"write and close blocked", func(g *channelGate) {
+			g.write = make(chan struct{})
+			g.close = make(chan struct{})
+		}},
+		// SendRequest blocked, so the request pump cannot return. The watchdog
+		// arms on observed source closure, not on that return.
+		{"write and requests blocked", func(g *channelGate) {
+			g.write = make(chan struct{})
+			g.request = make(chan struct{})
+		}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cancelled := make(chan error, 1)
+			f := newTestForwarder(t, abortConnection, cancelled)
+
+			gate := newChannelGate()
+			tt.setup(gate)
+			destination, source, requests, closeSource := forwardTestDirection(t, gate)
+
+			returned := make(chan struct{})
+			go func() {
+				defer close(returned)
+				f.channelDirection(destination, source, requests)
+			}()
+
+			if gate.request != nil {
+				// Gating SendRequest proves nothing unless a request is
+				// actually in flight through the serial sender.
+				requests <- &ssh.Request{Type: "window-change"}
+			}
+			closeSource()
+			close(requests) // source CLOSE, with no reply pending
+
+			select {
+			case err := <-cancelled:
+				require.ErrorIs(t, err, errSSHChannelDrainStalled)
+			case <-time.After(10 * time.Second):
+				t.Fatal("a stalled direction was never aborted")
+			}
+
+			// Cancelling proves the watchdog fired; it does not prove the
+			// direction unwinds. Release the gates and require that it does,
+			// or the goroutines this change exists to free are still stuck.
+			gate.releaseAll()
+			select {
+			case <-returned:
+			case <-time.After(10 * time.Second):
+				t.Fatal("channelDirection never returned after the abort")
+			}
+		})
+	}
+}
+
+// gateFirstChannelConn gates the first channel opened on this connection and
+// leaves every later one alone, so one stalled channel and one healthy channel
+// share a transport.
+type gateFirstChannelConn struct {
+	ssh.Conn
+	gate *channelGate
+	once sync.Once
+}
+
+func (c *gateFirstChannelConn) OpenChannel(name string, data []byte) (ssh.Channel, <-chan *ssh.Request, error) {
+	ch, reqs, err := c.Conn.OpenChannel(name, data)
+	if err != nil {
+		return nil, nil, err
+	}
+	gated := false
+	c.once.Do(func() { gated = true })
+	if !gated {
+		return ch, reqs, nil
+	}
+	return gatedChannel{Channel: ch, gate: c.gate}, reqs, nil
+}
+
+// forwardTestPeers builds the two connection pairs a forwarder sits between and
+// returns, in order: the client whose channel opens travel through the
+// forwarder, the forwarder's own downstream and upstream peers, and a snapshot
+// of everything the far upstream end has read from the channels it accepted.
+//
+// The client is returned separately from downstream because downstream is the
+// forwarder's own endpoint: a channel opened there travels out to the client
+// without the forwarder ever seeing it.
+func forwardTestPeers(t *testing.T) (client, downstream, upstream sshPeer, upstreamReceived func() string) {
+	t.Helper()
+	client, downstream = forwardTestPair(t, nil, nil)
+	upstream, far := forwardTestPair(t, nil, nil)
+	var mu sync.Mutex
+	var received []byte
+	// Read every channel the far upstream end is offered, for as long as it is
+	// offered any. Delivery is what "the tunnel still works" means, and nothing
+	// else on this side of the forwarder would consume these bytes.
+	go func() {
+		for {
+			channel := acceptTestChannel(far)
+			if channel == nil {
+				return
+			}
+			go func() {
+				chunk := make([]byte, 4096)
+				for {
+					n, err := channel.Read(chunk)
+					mu.Lock()
+					received = append(received, chunk[:n]...)
+					mu.Unlock()
+					if err != nil {
+						return
+					}
+				}
+			}()
+		}
+	}()
+	return client, downstream, upstream, func() string {
+		mu.Lock()
+		defer mu.Unlock()
+		return string(received)
+	}
+}
+
+// The forwarder also carries the host's connection, whose transport is the
+// reverse tunnel every guest's traffic rides. Cancelling that over one stalled
+// channel would end the session for everyone attached.
+//
+// This one has to go through forwardSSH rather than channelDirection, and the
+// two channels have to share the forwarded connection pair. A second direction
+// on its own connections proves nothing: the escalation closes *transports*, so
+// only a channel on the same transport can show that it survived. And survival
+// has to be delivery — channelDirection returns on failure just as readily as
+// on success.
+func TestHostScopedAbortLeavesTheTunnelWorking(t *testing.T) {
+	gate := newChannelGate()
+	gate.write = make(chan struct{})
+	defer close(gate.write)
+
+	// gateFirstChannelConn wraps the upstream so the first channel the
+	// forwarder opens is gated and the rest are untouched.
+	client, downstream, upstream, upstreamReceived := forwardTestPeers(t)
+	upstream.conn = &gateFirstChannelConn{Conn: upstream.conn, gate: gate}
+
+	forwarded := make(chan error, 1)
+	go func() { forwarded <- forwardSSH(t.Context(), downstream, upstream, abortChannel) }()
+
+	// The stalled channel: opened first, so it gets the gate.
+	stalled := openTestChannel(t, client)
+	_, err := stalled.Write([]byte("output for a guest that stopped reading"))
+	require.NoError(t, err)
+	require.NoError(t, stalled.Close()) // source CLOSE, arming the watchdog
+
+	select {
+	case <-gate.closed:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the stalled channel was never closed")
+	}
+
+	// That CLOSE gets a grace before a connection-scoped forwarder would give
+	// up and cancel, taking both transports with it. Outlast the grace before
+	// asking whether the transport survived, or the assertions below run in the
+	// window where even the wrong scope has not torn anything down yet.
+	time.Sleep(2 * sshForwardChannelAbortGrace)
+
+	// The tunnel is still up and still carrying traffic for everyone else.
+	live := openTestChannel(t, client)
+	const payload = "output for a guest that is still attached"
+	_, err = live.Write([]byte(payload))
+	require.NoError(t, err, "the shared transport was torn down")
+
+	require.Eventually(t, func() bool {
+		return strings.Contains(upstreamReceived(), payload)
+	}, 10*time.Second, 10*time.Millisecond,
+		"a stalled channel took the tunnel down with it")
+
+	select {
+	case err := <-forwarded:
+		t.Fatalf("the forwarder exited: %v", err)
+	default:
+	}
+}
+
+func TestChannelDirectionDoesNotAbortADrainingDestination(t *testing.T) {
+	cancelled := make(chan error, 1)
+	f := newTestForwarder(t, abortConnection, cancelled)
+
+	// Nothing gated: the destination accepts its bytes and closes normally.
+	destination, source, requests, closeSource := forwardTestDirection(t, newChannelGate())
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		f.channelDirection(destination, source, requests)
+	}()
+
+	// A direction whose source is still connected is simply idle, however long
+	// it stays that way. Outlast both watchdog timers before touching it: one
+	// that armed on anything other than source closure would close every live
+	// channel on the connection a drain timeout after it opened.
+	escalation := f.drainTimeout + f.abortGrace
+	select {
+	case err := <-cancelled:
+		t.Fatalf("a direction whose source was still connected escalated: %v", err)
+	case <-time.After(4 * escalation):
+	}
+
+	closeSource()
+	close(requests)
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("an ordinary close should not wait out the drain timeout")
+	}
+	// Outlast the timers again rather than sampling: the direction returns in
+	// microseconds, so a watchdog that escalated regardless of that return
+	// would still be counting down at this point.
+	select {
+	case err := <-cancelled:
+		t.Fatalf("an ordinary close escalated: %v", err)
+	case <-time.After(4 * escalation):
+	}
 }

--- a/server/sshforward_test.go
+++ b/server/sshforward_test.go
@@ -828,7 +828,7 @@ func TestSSHForwardTailAfterSourceCloseKeepsRequests(t *testing.T) {
 		go func() {
 			defer close(done)
 			sshForwarder{ctx: ctx, cancel: cancel}.requests(
-				sender, incoming, func() { aborts <- struct{}{} }, sshRequestAbortGrace, nil)
+				sender, incoming, nil, func() { aborts <- struct{}{} }, sshRequestAbortGrace, nil)
 		}()
 
 		// Occupy the serial sender, so everything after this is queued rather
@@ -1390,4 +1390,43 @@ func TestSSHForwardAbortCutsBufferedData(t *testing.T) {
 	if n := forwardTestReceive(t, written); n >= sent {
 		t.Fatalf("origin wrote all %d bytes; the copy was never actually blocked", sent)
 	}
+}
+
+// The stalled-direction watchdog has to arm on source closure itself, not on
+// the teardown reaching a particular line: the serial sender can still be
+// blocked in SendRequest, and the deferred wait for it means requests would not
+// return.
+func TestRequestsReportsSourceClosureWhileTheSenderIsBlocked(t *testing.T) {
+	incoming := make(chan *ssh.Request)
+	blocked := make(chan struct{})
+	defer close(blocked)
+
+	entered := make(chan struct{})
+	var enterOnce sync.Once
+	sender := senderFunc(func(string, bool, []byte) (bool, []byte, error) {
+		enterOnce.Do(func() { close(entered) })
+		<-blocked
+		return false, nil, nil
+	})
+
+	closed := make(chan struct{})
+	f := sshForwarder{ctx: t.Context(), cancel: func(error) {}}
+	go f.requests(sender, incoming, sync.OnceFunc(func() { close(closed) }), nil, 0, nil)
+
+	incoming <- &ssh.Request{Type: "window-change"}
+	<-entered // the sender has dispatched the request and is blocked in SendRequest
+	close(incoming)
+
+	select {
+	case <-closed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("source closure was not reported while the sender was blocked")
+	}
+}
+
+// senderFunc adapts a function to sshRequestSender.
+type senderFunc func(string, bool, []byte) (bool, []byte, error)
+
+func (s senderFunc) SendRequest(name string, wantReply bool, payload []byte) (bool, []byte, error) {
+	return s(name, wantReply, payload)
 }

--- a/server/sshforward_test.go
+++ b/server/sshforward_test.go
@@ -1456,6 +1456,18 @@ func newChannelGate() *channelGate {
 	return &channelGate{closed: make(chan struct{})}
 }
 
+// closeCalled reports whether the gated channel has been closed. With Write
+// gated, channelDirection never reaches its own Close, so this is only ever
+// true because the watchdog acted.
+func (g *channelGate) closeCalled() bool {
+	select {
+	case <-g.closed:
+		return true
+	default:
+		return false
+	}
+}
+
 // releaseAll unblocks every gated method, so a test can require that the code
 // under test actually unwinds rather than merely that it fired a callback.
 func (g *channelGate) releaseAll() {
@@ -1646,6 +1658,50 @@ func TestChannelDirectionAbortsAStalledDestination(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Once the connection is draining, forwardSSH owns the bound on a stalled
+// channel and the watchdog must keep its hands off.
+//
+// Both bounds arm within moments of each other on a shutdown, and before this
+// they ran on identical timeouts — sshForwardChannelDrainTimeout equalled
+// sshForwardDrainTimeout — so which one resolved the stall came down to
+// scheduling. Closing the channel first completes the drain loop and suppresses
+// the "drain timed out" error TestSSHForwardTransportDrainBounded requires,
+// which is how this surfaced: as an error-message flake on Windows CI, on a
+// test that had nothing to do with this change.
+//
+// Nothing is lost by standing down. forwardSSH closes both transports when its
+// own timer expires, which releases a blocked write more thoroughly than
+// closing one channel does.
+func TestChannelDirectionYieldsAStalledChannelToTheTransportDrain(t *testing.T) {
+	cancelled := make(chan error, 1)
+	f := newTestForwarder(t, abortConnection, cancelled)
+
+	// Already draining when the direction starts, so the watchdog has to decline
+	// at its first decision point rather than mid-wait.
+	draining := make(chan struct{})
+	close(draining)
+	f.draining = draining
+
+	gate := newChannelGate()
+	gate.write = make(chan struct{})
+	destination, source, requests, closeSource := forwardTestDirection(t, gate)
+
+	go f.channelDirection(destination, source, requests)
+	closeSource()
+	close(requests)
+
+	// Well past f.drainTimeout plus f.abortGrace, which together are 150ms here.
+	select {
+	case err := <-cancelled:
+		t.Fatalf("the watchdog aborted a draining connection: %v", err)
+	case <-time.After(time.Second):
+	}
+	require.False(t, gate.closeCalled(),
+		"the watchdog closed a channel a draining connection was already bounding")
+
+	gate.releaseAll()
 }
 
 // gateFirstChannelConn gates the first channel opened on this connection and

--- a/server/sshstock.go
+++ b/server/sshstock.go
@@ -51,6 +51,20 @@ func upstreamFailureReason(err error) error {
 	}
 }
 
+// abortScopeFor decides how far a stalled channel on this connection may
+// escalate, from the same client version the metrics below count. A host's
+// transport carries the reverse tunnel every guest's traffic rides, so a
+// stalled channel on it must never take it down; a guest's transport is that
+// guest's alone. Getting this backwards costs a host's whole session the first
+// time any one guest stops reading, so it is a function with a test rather than
+// a condition inline at the call.
+func abortScopeFor(clientVersion string) sshAbortScope {
+	if clientVersion == upterm.HostSSHClientVersion {
+		return abortChannel
+	}
+	return abortConnection
+}
+
 // isRecoverableAcceptError reports whether Accept is worth retrying. A timeout
 // comes from a deadline set on a wrapped listener; the rest are resource
 // exhaustion, which clears as open connections drain and which taking the
@@ -214,12 +228,13 @@ func (p *SSHRouting) stockConnection(ctx context.Context, raw net.Conn, inst *ro
 				defer func() { _ = upstream.Close() }()
 				if err = upstreamRaw.SetDeadline(time.Time{}); err == nil {
 					cancel()
-					if string(downstream.ClientVersion()) == upterm.HostSSHClientVersion {
+					clientVersion := string(downstream.ClientVersion())
+					if clientVersion == upterm.HostSSHClientVersion {
 						inst.authenticatedHost.Add(1)
 					} else {
 						inst.authenticatedClient.Add(1)
 					}
-					return forwardSSH(ctx, peer, sshPeer{upstream, upstreamChannels, upstreamRequests})
+					return forwardSSH(ctx, peer, sshPeer{upstream, upstreamChannels, upstreamRequests}, abortScopeFor(clientVersion))
 				}
 			}
 		}

--- a/server/sshstock_test.go
+++ b/server/sshstock_test.go
@@ -336,6 +336,36 @@ func TestStockSSHAcceptRetriesResourceExhaustion(t *testing.T) {
 		"every recoverable accept failure should be retried, not returned")
 }
 
+// Only the host gets the narrow scope. Swapping these two constants leaves
+// every behavioural test in the package green — the forwarder tests hand
+// forwardSSH a scope directly — while costing a host every guest attached to
+// its session the first time one of them stops reading.
+func TestAbortScopeForClientVersion(t *testing.T) {
+	for _, tt := range []struct {
+		name          string
+		clientVersion string
+		want          sshAbortScope
+	}{
+		// A host's transport carries the reverse tunnel; it must survive.
+		{"host", upterm.HostSSHClientVersion, abortChannel},
+		// Everything else is one guest's own connection.
+		{"guest", upterm.ClientSSHClientVersion, abortConnection},
+		{"unknown client", "SSH-2.0-OpenSSH_9.6", abortConnection},
+		{"empty", "", abortConnection},
+		// Near-misses must not be mistaken for the host: the check is exact,
+		// and a prefix or suffix match would hand a guest the host's scope.
+		{"host prefix", upterm.HostSSHClientVersion + "-2", abortConnection},
+		{"host suffix", "x" + upterm.HostSSHClientVersion, abortConnection},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, abortScopeFor(tt.clientVersion))
+		})
+	}
+	// The two scopes must stay distinguishable; a single-valued type would make
+	// every assertion above vacuous.
+	require.NotEqual(t, abortChannel, abortConnection)
+}
+
 func TestRecoverableAcceptErrors(t *testing.T) {
 	syscallErr := func(errno syscall.Errno) error {
 		return &net.OpError{Op: "accept", Net: "tcp", Err: os.NewSyscallError("accept4", errno)}


### PR DESCRIPTION
`MultiWriter` writes to every attached guest serially inside one `Write`, so a guest that stops reading its SSH channel blocks there once its 2 MiB channel window fills and holds up every writer behind it — including the host's own terminal. #523 fixed the parts of this that lost data or tore down sessions; head-of-line blocking is what it left, and it needs a design change.

Three parts: each guest gets a bounded sink, the fan-out gains the flush barrier that asynchronous delivery would otherwise break, and dropping a guest is made to actually disconnect it.

## Each guest gets a bounded sink

`io.AsyncWriter` buffers into a byte-bounded `pending` slice and delivers from one goroutine, so `Write` performs no I/O and never blocks. `host/internal.HandleSession` wraps each guest's filtered writer in one. The host's own stdout stays attached directly — synchronous, never buffered, never dropped.

The bound is bytes rather than writes because pty writes run from one byte to `io.Copy`'s 32 KiB, so a count of writes is not a bound on memory at all. Overflow past 1 MiB (`DefaultGuestBufferSize`) fails the sink permanently instead of discarding bytes out of the middle: a guest that misses a region of a terminal stream cannot detect it, and its screen is silently wrong from then on. Dropping the viewer is the honest outcome, and `MultiWriter` already removes a writer that errors, so overflow needed no new plumbing there.

Delivery is chunked at 64 KiB, which is load-bearing rather than cosmetic. `TerminalQueryFilter.Write` copies each batch into `outBuf` and only ever resets it with `outBuf[:0]`, so its capacity settles at the largest batch it has ever seen and stays there for the filter's life; uncapped coalescing would park a megabyte per guest for the session.

## The flush barrier

Today, when the pty copy returns, every guest has already been written to. Asynchronous delivery breaks that guarantee, which would cost the tail of every session — the last screenful, the command's own exit output.

`MultiWriter.Shutdown(ctx)` closes the fan-out to new attachments under `writeMu`, the same lock `Append` takes, and then flushes every buffering member in parallel. The two halves are inseparable: flushing a snapshot alone leaves a window where the SSH server is still serving, so a guest attaching mid-flush has its replay queued into a sink that nothing will ever flush, and teardown then closes it undelivered.

It runs in the output actor's `defer`, where `io.Copy` from the pty has returned, bounded at one second per guest. Two lifetime bugs had to be fixed for it to mean anything: guest sessions now stay open across it, via a `sessionContext` detached with `context.WithoutCancel`, so a cancelled parent cannot close the sinks mid-flush; and `server.Shutdown` is handed that detached context rather than the live parent, which on a command-led exit would have waited forever.

## Dropping a guest has to disconnect it

Removing a guest from the fan-out and closing its session is not enough when the guest is stalled. `Close()` only *sends* a CLOSE, and `x/crypto/ssh` takes the channel's write lock to send it — the same lock the blocked write is already holding. Teardown blocked on the thing it was tearing down.

`server/sshforward.go` now arms an independent watchdog per direction when that direction's source closes: five seconds to drain, one second of grace, then `destination.Close()` from its own goroutine, so escalation cannot be blocked by the stall it exists to resolve. The request pump reports source closure through a new `sourceClosed` callback to arm it.

Scope matters here because the same forwarder also carries host connections, whose transport *is* the reverse tunnel: aborting the connection there would kill the session for everyone. `abortScopeFor` reads the client version and inverts the unit accordingly — a host gets its stalled channel aborted alone, while a guest's whole connection is fair game, since it carries nothing but that guest.

## What this costs

**A guest that is merely slower than the host can still be dropped.** The cap sets how long a slow guest survives, not whether. Once its source stops pacing it, backlog accrues at the difference between the host's ingest rate and the guest's drain rate, and a sustained mismatch exhausts any finite cap. Total slack is roughly 5 MiB — the 1 MiB buffer plus a 2 MiB SSH window on each of the two legs. On a 10 Mbit/s guest link against a 5 MB/s host terminal, that is a drop about 7 MB into an unthrottled `cat`.

Raising the cap is not the lever: 1 MiB → 16 MiB buys roughly four seconds against a 4 MB/s deficit and does not make a large `cat` survivable. Only a staleness signal distinguishes "stalled" from "slower", and that was considered and declined as the wrong first step. This is still strictly better than master, where the same `cat` freezes the host and every guest for the whole transfer — a 100 MB file at 125 KB/s is thirteen minutes of dead session for everyone.

**The sharp edge is a host whose stdout is not a terminal.** `command.Run` gates raw mode and stdin forwarding on `term.IsTerminal` but attaches `c.stdout` unconditionally, so `upterm host -- ./thing > out.log`, or any CI- or daemon-shaped host, reads the pty at memory bandwidth and *nothing* paces the session. Every guest is then dropped by any burst past ~5 MiB regardless of link quality. In ordinary interactive use a real terminal emulator runs at single-digit MB/s and the two rates are close.

**Write boundaries are not preserved for guests.** A guest that falls behind receives writes coalesced up to 64 KiB. It is a byte stream to a terminal, so nothing downstream depends on them.

**`Append` can now block on the host's terminal.** If the host's stdout is stopped, a guest joining waits in `Append` until it resumes, where before it would attach and then receive nothing. The guest's experience is the same either way; what changes is where the handler waits.

## Smaller

- `MultiWriter.Append` is atomic: the replay and the attach happen under `writeMu` together, so a joining guest gets the replay and every write after it — never a write that is also in its replay, never a gap between the two. This is only safe because attached guest writers no longer block on I/O; under the old design it would have reintroduced the deadlock #523 removed.
- The replay buffer's `Data()` allocated `make([][]byte, len(queue))` and then appended to it, returning twice the entries with the first half `nil` — so every replay issued that many empty writes before the real ones. `Append` now also ignores a non-positive size rather than indexing off the end, and the dead `Size()` is gone.
- The read-only banner goes through the guest's sink rather than straight to the session, so it stays ordered behind the replay handed over during attach and cannot block the handler on a guest that is not draining. `HandleSession` is now driven directly in a test through a fake `gssh.Session`, which is what makes that deterministic.
- `AsyncWriter` drops its pending slice when the drain empties it. Re-slicing past the delivered bytes shrinks length and capacity but leaves the slice pointing inside the array `append` grew, and Go frees an allocation only as a whole: measured on a 512 KiB burst, 589 KiB stayed resident after a full drain, 5 KiB after the release.

## Verification

`make test` green, zero `FAIL` lines, including `ftests`. The `io` package is at 93.9% statement coverage; `io` and `host/internal` are also clean at `-count=10`.

New end-to-end coverage in `ftests/slowguest_test.go` runs a real stalled guest through real SSH: a helper binary re-exec'd through `os.Args[0]` bursts output while a guest holds its connection without draining, and the test asserts the guest is dropped while the host and a second guest keep running. A companion test covers the host exiting while a guest still holds its connection.

Every test added here was checked by deleting the behaviour it names and confirming it fails for that reason. That check earned its keep: it caught six tests across this branch that would otherwise have passed vacuously.

Not verified locally: the manual interactive check (`Ctrl-Z` a guest's client, `cat` a large file) needs a real terminal and two SSH clients, and Windows/ConPTY behaviour — CI is its first real exercise.
