### PR TITLE
Follow-ups from the output fan-out work: logging, a lazy watchdog, and Flush coverage

### DIFF
--- a/host/internal/command.go
+++ b/host/internal/command.go
@@ -28,6 +28,13 @@ const (
 	// deliberately not dropped for that, because the session is ending and a
 	// slow last second is not an overflow.
 	guestFlushTimeout = time.Second
+	// guestFlushLogTimeout bounds how long exit waits for the warning about
+	// that flush to be written. Generous for any handler that is working, so
+	// the line lands before the host tears down and stays in order with what
+	// follows it; short enough that a handler blocked on a stopped terminal
+	// cannot hold the exit open. Both halves matter — fire-and-forget loses the
+	// line, waiting outright hangs the host.
+	guestFlushLogTimeout = 100 * time.Millisecond
 )
 
 // activityWriter records when it last wrote, so a drain can stop once output
@@ -198,17 +205,31 @@ func (c *command) Run() error {
 					// whose last screenful never arrived, which looks from the
 					// outside exactly like output the command never produced.
 					//
-					// Off this goroutine, because this defer is the output
-					// actor's return path: run.Group cannot finish until it
-					// returns, so a slog handler blocked on a stopped terminal
-					// would hang the host's exit outright and make
-					// guestFlushTimeout bound nothing. One goroutine per call
-					// of Run, which is once per host process, so the objection
-					// to fire-and-forget logging on the forwarder's uncapped
-					// channels does not arise here. The host has real teardown
-					// left to do, so a working logger has ample time to write.
-					go c.logger.Warn("gave up delivering final output to a guest",
-						"timeout", guestFlushTimeout, "error", err)
+					// Written off this goroutine but waited for, under a bound.
+					//
+					// This defer is the output actor's return path, and
+					// run.Group cannot finish until it returns, so writing here
+					// directly would let a handler blocked on a stopped
+					// terminal hang the host's exit and leave guestFlushTimeout
+					// bounding nothing. Not waiting at all trades that for a
+					// quieter fault: Go abandons runnable goroutines at process
+					// exit, so the one diagnostic this path produces could be
+					// lost, or land after the shutdown lines it should precede,
+					// with a perfectly healthy logger.
+					//
+					// Waiting under a bound is the only form with neither
+					// failure. One goroutine per call of Run, which is once per
+					// host process.
+					logged := make(chan struct{})
+					go func() {
+						defer close(logged)
+						c.logger.Warn("gave up delivering final output to a guest",
+							"timeout", guestFlushTimeout, "error", err)
+					}()
+					select {
+					case <-logged:
+					case <-time.After(guestFlushLogTimeout):
+					}
 				}
 			}()
 			defer close(done)

--- a/host/internal/command.go
+++ b/host/internal/command.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"os/exec"
 	"sync/atomic"
@@ -77,6 +78,7 @@ func newCommand(
 	stdout *os.File,
 	eventEmitter *emitter.Emitter,
 	writers *uio.MultiWriter,
+	logger *slog.Logger,
 	forceForwardingInputForTesting bool,
 ) *command {
 	return &command{
@@ -87,6 +89,7 @@ func newCommand(
 		stdout:                         stdout,
 		eventEmitter:                   eventEmitter,
 		writers:                        writers,
+		logger:                         logger,
 		forceForwardingInputForTesting: forceForwardingInputForTesting,
 	}
 }
@@ -105,6 +108,7 @@ type command struct {
 	writers *uio.MultiWriter
 
 	eventEmitter *emitter.Emitter
+	logger       *slog.Logger
 
 	ctx context.Context
 
@@ -186,7 +190,16 @@ func (c *command) Run() error {
 			defer func() {
 				flushCtx, cancelFlush := context.WithTimeout(context.WithoutCancel(c.ctx), guestFlushTimeout)
 				defer cancelFlush()
-				_ = c.writers.Shutdown(flushCtx)
+				if err := c.writers.Shutdown(flushCtx); err != nil {
+					// Not a host failure, and nothing to do about it here: a
+					// guest still stuck when the deadline expires loses its tail
+					// by design, and a guest already gone flushes to nil. Worth
+					// a line because otherwise the only evidence is a guest
+					// whose last screenful never arrived, which looks from the
+					// outside exactly like output the command never produced.
+					c.logger.Warn("gave up delivering final output to a guest",
+						"timeout", guestFlushTimeout, "error", err)
+				}
 			}()
 			defer close(done)
 			_, err := io.Copy(output, uio.NewContextReader(ctx, c.ptmx))

--- a/host/internal/command.go
+++ b/host/internal/command.go
@@ -197,7 +197,17 @@ func (c *command) Run() error {
 					// a line because otherwise the only evidence is a guest
 					// whose last screenful never arrived, which looks from the
 					// outside exactly like output the command never produced.
-					c.logger.Warn("gave up delivering final output to a guest",
+					//
+					// Off this goroutine, because this defer is the output
+					// actor's return path: run.Group cannot finish until it
+					// returns, so a slog handler blocked on a stopped terminal
+					// would hang the host's exit outright and make
+					// guestFlushTimeout bound nothing. One goroutine per call
+					// of Run, which is once per host process, so the objection
+					// to fire-and-forget logging on the forwarder's uncapped
+					// channels does not arise here. The host has real teardown
+					// left to do, so a working logger has ample time to write.
+					go c.logger.Warn("gave up delivering final output to a guest",
 						"timeout", guestFlushTimeout, "error", err)
 				}
 			}()

--- a/host/internal/command_test.go
+++ b/host/internal/command_test.go
@@ -62,6 +62,7 @@ func TestCommand_NonTTY_WithForceFlag(t *testing.T) {
 		stdoutw,
 		ee,
 		writers,
+		discardLogger(),
 		true, // Force stdin forwarding even though it's not a TTY
 	)
 
@@ -167,6 +168,7 @@ func TestCommand_ContextCancellation(t *testing.T) {
 		stdoutw,
 		ee,
 		writers,
+		discardLogger(),
 		false,
 	)
 
@@ -253,6 +255,7 @@ func TestCommand_DrainsOutputAfterExit(t *testing.T) {
 
 	const lastLine = "written just before exit"
 	cmd := &command{
+		logger:  discardLogger(),
 		stdin:   stdinr,
 		stdout:  stdoutw,
 		writers: uio.NewMultiWriter(5),

--- a/host/internal/command_unix_test.go
+++ b/host/internal/command_unix_test.go
@@ -55,6 +55,7 @@ func TestCommand_Unix_PTY(t *testing.T) {
 		stdoutw,
 		ee,
 		writers,
+		discardLogger(),
 		false, // Should not be needed for real TTY
 	)
 

--- a/host/internal/command_windows_test.go
+++ b/host/internal/command_windows_test.go
@@ -37,6 +37,7 @@ func TestCommand_Windows_BasicExecution(t *testing.T) {
 		stdoutw,
 		ee,
 		writers,
+		discardLogger(),
 		false,
 	)
 
@@ -85,6 +86,7 @@ func TestCommand_Windows_JobObject(t *testing.T) {
 		stdoutw,
 		ee,
 		writers,
+		discardLogger(),
 		false,
 	)
 
@@ -173,6 +175,7 @@ func TestCommand_Windows_ConPTY(t *testing.T) {
 		stdoutw,
 		ee,
 		writers,
+		discardLogger(),
 		false,
 	)
 

--- a/host/internal/fanout_test.go
+++ b/host/internal/fanout_test.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"slices"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -159,7 +160,13 @@ func TestCommandRunLogsAGuestThatNeverReceivedItsTail(t *testing.T) {
 	}
 
 	require.NoError(t, cmd.Run())
-	require.Contains(t, string(logs.bytes()), "gave up delivering final output to a guest",
+
+	// Waited for rather than read once: the line is emitted off the output
+	// actor's return path, so that a blocked logger cannot hang the host's
+	// exit. Run returning therefore says nothing about whether it has landed.
+	require.Eventually(t, func() bool {
+		return strings.Contains(string(logs.bytes()), "gave up delivering final output to a guest")
+	}, 5*time.Second, time.Millisecond,
 		"a guest that lost its tail left no trace in the host log")
 }
 

--- a/host/internal/fanout_test.go
+++ b/host/internal/fanout_test.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"os"
 	"slices"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -161,13 +160,65 @@ func TestCommandRunLogsAGuestThatNeverReceivedItsTail(t *testing.T) {
 
 	require.NoError(t, cmd.Run())
 
-	// Waited for rather than read once: the line is emitted off the output
-	// actor's return path, so that a blocked logger cannot hang the host's
-	// exit. Run returning therefore says nothing about whether it has landed.
-	require.Eventually(t, func() bool {
-		return strings.Contains(string(logs.bytes()), "gave up delivering final output to a guest")
-	}, 5*time.Second, time.Millisecond,
+	// No Eventually, deliberately. The line is written off the actor's return
+	// path so a blocked handler cannot hang the exit, but it is waited for
+	// under a bound, so with a working handler it has landed by the time Run
+	// returns. Asserting immediately is what pins that: a fire-and-forget
+	// version passes under Eventually and still loses the line at process
+	// exit, which is the whole failure being guarded against.
+	require.Contains(t, string(logs.bytes()), "gave up delivering final output to a guest",
 		"a guest that lost its tail left no trace in the host log")
+}
+
+// The other half of that bound: a handler that never returns must not hold the
+// host open. Exit waits for the warning, so the wait needs its own ceiling, or
+// guestFlushTimeout would bound the flush and then the logger would hang the
+// process anyway — with stdout redirected and stderr on a stopped terminal,
+// which is exactly the shape of session this whole change exists for.
+func TestCommandRunDoesNotHangOnABlockedLogger(t *testing.T) {
+	stdinr, stdinw, err := os.Pipe()
+	require.NoError(t, err)
+	defer func() { _ = stdinr.Close() }()
+	defer func() { _ = stdinw.Close() }()
+	stdoutr, stdoutw, err := os.Pipe()
+	require.NoError(t, err)
+	defer func() { _ = stdoutr.Close() }()
+	go func() { _, _ = io.Copy(io.Discard, stdoutr) }()
+
+	// Stuck guest, so the flush fails and there is a warning to write at all.
+	guestGate := make(chan struct{})
+	defer close(guestGate)
+	guest := uio.NewAsyncWriter(&gatedWriter{gate: guestGate, rec: &recordingWriter{}},
+		uio.DefaultGuestBufferSize, nil)
+	defer func() { _ = guest.Close() }()
+
+	writers := uio.NewMultiWriter(5)
+	require.NoError(t, writers.Append(guest))
+
+	// And a handler that never returns from Write.
+	logGate := make(chan struct{})
+	defer close(logGate)
+	cmd := &command{
+		logger:  slog.New(slog.NewTextHandler(&gatedWriter{gate: logGate, rec: &recordingWriter{}}, nil)),
+		stdin:   stdinr,
+		stdout:  stdoutw,
+		writers: writers,
+		ctx:     t.Context(),
+		ptmx: &exitedPTY{
+			pending:   [][]byte{[]byte("never delivered\r\n")},
+			readDelay: 20 * time.Millisecond,
+		},
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- cmd.Run() }()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("a blocked logger held the host's exit open")
+	}
 }
 
 // The shutdown barrier: waitIdle can return while the producer is still going,

--- a/host/internal/fanout_test.go
+++ b/host/internal/fanout_test.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"context"
 	"io"
+	"log/slog"
 	"os"
 	"slices"
 	"sync"
@@ -99,6 +100,7 @@ func TestCommandRunFlushesAcceptedOutputBeforeReturning(t *testing.T) {
 	require.NoError(t, writers.Append(guest))
 
 	cmd := &command{
+		logger:  discardLogger(),
 		stdin:   stdinr,
 		stdout:  stdoutw,
 		writers: writers,
@@ -114,6 +116,51 @@ func TestCommandRunFlushesAcceptedOutputBeforeReturning(t *testing.T) {
 	// No Eventually: the guarantee is that this has already happened.
 	require.Contains(t, string(guestOut.bytes()), lastLine,
 		"Run returned with output still queued for an attached guest")
+}
+
+// A guest too stuck to receive its tail must leave a trace.
+//
+// The flush is best-effort by design: the deadline expires, the host exits, and
+// there is nothing to be done about it here. That is exactly why the error was
+// easy to discard — and why discarding it is wrong. Without a line, a guest
+// whose last screenful never arrived looks from the outside like output the
+// command never produced.
+func TestCommandRunLogsAGuestThatNeverReceivedItsTail(t *testing.T) {
+	stdinr, stdinw, err := os.Pipe()
+	require.NoError(t, err)
+	defer func() { _ = stdinr.Close() }()
+	defer func() { _ = stdinw.Close() }()
+	stdoutr, stdoutw, err := os.Pipe()
+	require.NoError(t, err)
+	defer func() { _ = stdoutr.Close() }()
+	go func() { _, _ = io.Copy(io.Discard, stdoutr) }()
+
+	// Never released, so the flush can only end at its deadline.
+	gate := make(chan struct{})
+	defer close(gate)
+	guest := uio.NewAsyncWriter(&gatedWriter{gate: gate, rec: &recordingWriter{}},
+		uio.DefaultGuestBufferSize, nil)
+	defer func() { _ = guest.Close() }()
+
+	writers := uio.NewMultiWriter(5)
+	require.NoError(t, writers.Append(guest))
+
+	var logs recordingWriter
+	cmd := &command{
+		logger:  slog.New(slog.NewTextHandler(&logs, nil)),
+		stdin:   stdinr,
+		stdout:  stdoutw,
+		writers: writers,
+		ctx:     t.Context(),
+		ptmx: &exitedPTY{
+			pending:   [][]byte{[]byte("never delivered\r\n")},
+			readDelay: 20 * time.Millisecond,
+		},
+	}
+
+	require.NoError(t, cmd.Run())
+	require.Contains(t, string(logs.bytes()), "gave up delivering final output to a guest",
+		"a guest that lost its tail left no trace in the host log")
 }
 
 // The shutdown barrier: waitIdle can return while the producer is still going,
@@ -156,6 +203,7 @@ func TestCommandRunLosesNothingWhenTheProducerOutlivesWaitIdle(t *testing.T) {
 		pending = append(pending, []byte{byte('a' + i%26)})
 	}
 	cmd := &command{
+		logger:  discardLogger(),
 		stdin:   stdinr,
 		stdout:  stdoutw,
 		writers: writers,

--- a/host/internal/server.go
+++ b/host/internal/server.go
@@ -92,6 +92,7 @@ func (s *Server) ServeWithContext(ctx context.Context, l net.Listener) error {
 		s.Stdout,
 		s.EventEmitter,
 		writers,
+		s.Logger,
 		s.ForceForwardingInputForTesting,
 	)
 	ptmx, err := cmd.Start(cmdCtx)

--- a/io/async_writer_test.go
+++ b/io/async_writer_test.go
@@ -446,6 +446,109 @@ func TestAsyncWriterFlushGivesUpOnAStuckSink(t *testing.T) {
 		"a stuck guest must not hold up shutdown")
 }
 
+// stepWriter delivers one write per token, so a test can park the drain at a
+// chosen point in a backlog and observe what has and has not been delivered
+// while it is standing still.
+type stepWriter struct {
+	recordingWriter
+	step chan struct{}
+}
+
+func newStepWriter() *stepWriter { return &stepWriter{step: make(chan struct{})} }
+
+func (s *stepWriter) Write(p []byte) (int, error) {
+	<-s.step
+	return s.recordingWriter.Write(p)
+}
+
+// release lets exactly one write through, waits for it to land, and reports the
+// running total. It waits on progress rather than on an expected size: the
+// drain coalesces whatever is pending when it takes a chunk, so how the backlog
+// divides into writes is not fixed.
+func (s *stepWriter) release(t *testing.T) int {
+	t.Helper()
+	before := len(s.bytes())
+	select {
+	case s.step <- struct{}{}:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the drain never reached its next write")
+	}
+	var after int
+	require.Eventually(t, func() bool { after = len(s.bytes()); return after > before },
+		5*time.Second, time.Millisecond, "the released write never landed")
+	return after
+}
+
+// Flush must not return until a whole backlog has been delivered, not merely
+// until the write that was in flight when it was called returns.
+//
+// The observation point is the whole test. Releasing the backlog all at once
+// proves nothing: the drain finishes it in microseconds, so a Flush that
+// returned far too early still looks correct by the time an assertion runs —
+// measured, with both mechanisms below deliberately broken, and it passed.
+// Stepping one write at a time and asserting while the drain is parked is what
+// makes an early return observable.
+//
+// Two mechanisms hold the contract up: the drain publishes idle only on the
+// pass that finds pending empty, and Flush re-checks the condition rather than
+// trusting a single wake-up. Either alone is sufficient, so no single mutation
+// fails this — it guards the contract, not one of its two supports.
+func TestAsyncWriterFlushSpansAMultiChunkBacklog(t *testing.T) {
+	step := newStepWriter()
+	a := NewAsyncWriter(step, DefaultGuestBufferSize, nil)
+	defer func() { _ = a.Close() }()
+
+	// One small write to park the drain, then four chunks' worth behind it at
+	// io.Copy's write size, so delivery provably takes more than one pass.
+	const blocks = 8
+	block := bytes.Repeat([]byte("x"), 32<<10)
+	_, err := a.Write([]byte("first"))
+	require.NoError(t, err)
+	for range blocks {
+		_, err := a.Write(block)
+		require.NoError(t, err)
+	}
+	total := len("first") + blocks*len(block)
+
+	flushed := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		flushed <- a.Flush(ctx)
+	}()
+
+	// Step the backlog through one write at a time, and after every write that
+	// leaves something owed, require that Flush is still waiting. Checking only
+	// once would not do it: Flush may not even have parked before the first
+	// write completes, so an early return would happen later in the backlog,
+	// where a single check is not looking — measured, with both mechanisms
+	// broken, and it passed.
+	delivered := step.release(t)
+	require.Less(t, delivered, total, "the backlog must not fit in one write")
+	for delivered < total {
+		select {
+		case err := <-flushed:
+			t.Fatalf("Flush returned with %d of %d bytes delivered: %v", delivered, total, err)
+		case <-time.After(50 * time.Millisecond):
+		}
+		delivered = step.release(t)
+	}
+
+	select {
+	case err := <-flushed:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("Flush never returned after the backlog drained")
+	}
+
+	// Compared as a count: the failure is a short delivery, and asserting on the
+	// bytes themselves would render a quarter of a megabyte.
+	require.Equal(t, total, len(step.bytes()),
+		"Flush returned with part of the backlog still undelivered")
+	require.Greater(t, len(step.writeSizes()), 1,
+		"the backlog must have taken more than one pass, or this proves nothing")
+}
+
 func TestAsyncWriterFlushAfterCloseReturnsImmediately(t *testing.T) {
 	gate := newGateWriter()
 	defer close(gate.release)

--- a/server/sshforward.go
+++ b/server/sshforward.go
@@ -432,30 +432,37 @@ func (f sshForwarder) abortStalledDirection(destination ssh.Channel, finished <-
 	// enough whenever the peer is still reading its socket: it answers the
 	// CLOSE, and x/crypto's channel teardown fails the pending write.
 	go func() { _ = destination.Close() }()
-	// Reported after the close is under way, and from a goroutine, because a
-	// slog handler is one more thing that can block: a daemon whose stderr is a
-	// pipe nobody drains blocks in Write like any other backpressured sink.
-	// Logging on this path would make the bound this watchdog exists to provide
-	// conditional on the logger being drained, which is the exact shape of
-	// problem it was written to avoid.
-	//
-	// It is the daemon's only account of a dropped guest. The host logs why it
-	// stopped feeding one, but from here the guest simply stops, and which of
-	// the two happened is the difference between a slow viewer and a broken
-	// forwarder.
-	go f.log().Warn("closing a stalled SSH channel; its source closed and the copy never drained",
-		"drain_timeout", f.drainTimeout)
-	if f.settledWithin(finished, f.abortGrace) {
-		return
-	}
-	if f.scope == abortConnection {
+
+	cancelledConnection := false
+	if !f.settledWithin(finished, f.abortGrace) && f.scope == abortConnection {
+		// The expensive step: every other channel on this connection goes with
+		// it, undrained.
 		f.cancel(errSSHChannelDrainStalled)
-		// The expensive step, and the one worth a line of its own: every other
-		// channel on this connection goes with it, undrained. Ordered after the
-		// cancel for the same reason as above.
-		go f.log().Warn("stalled SSH channel did not answer CLOSE; cancelled the connection",
-			"abort_grace", f.abortGrace)
+		cancelledConnection = true
 	}
+
+	// Last, once every bound this function exists to apply has been applied,
+	// and synchronously.
+	//
+	// A slog handler is one more thing that can block — a daemon whose stderr
+	// is a pipe nobody drains blocks in Write like any other backpressured sink
+	// — so logging before the close or the cancel would make those bounds
+	// conditional on the logger being drained, which is the shape of problem
+	// this watchdog was written to prevent. Logging from a goroutine instead
+	// would fix that and buy a worse one: a handler that stays backpressured
+	// leaves one abandoned goroutine per stall, and established channels are
+	// deliberately uncapped. Placed here it holds the watchdog's own goroutine,
+	// which has finished its work and was about to exit anyway, and adds
+	// nothing that was not already there.
+	//
+	// This is the daemon's only account of a dropped guest. The host logs why
+	// it stopped feeding one, but from here the guest simply stops, and which
+	// of the two happened is the difference between a slow viewer and a broken
+	// forwarder.
+	f.log().Warn("closed a stalled SSH channel; its source closed and the copy never drained",
+		"drain_timeout", f.drainTimeout,
+		"abort_grace", f.abortGrace,
+		"cancelled_connection", cancelledConnection)
 }
 
 // log is nil-safe so that every way of building a forwarder, including test

--- a/server/sshforward.go
+++ b/server/sshforward.go
@@ -427,26 +427,34 @@ func (f sshForwarder) abortStalledDirection(destination ssh.Channel, finished <-
 	if f.settledWithin(finished, f.drainTimeout) {
 		return
 	}
-	// The daemon's only account of a dropped guest: the host logs why it
-	// stopped feeding one, but from here the guest simply stops, and which of
-	// the two happened is the difference between a slow viewer and a broken
-	// forwarder.
-	f.log().Warn("closing a stalled SSH channel; its source closed and the copy never drained",
-		"drain_timeout", f.drainTimeout)
 	// In its own goroutine, for the reason above. A write blocked on an
 	// exhausted window does not hold the channel's write mutex, so this is
 	// enough whenever the peer is still reading its socket: it answers the
 	// CLOSE, and x/crypto's channel teardown fails the pending write.
 	go func() { _ = destination.Close() }()
+	// Reported after the close is under way, and from a goroutine, because a
+	// slog handler is one more thing that can block: a daemon whose stderr is a
+	// pipe nobody drains blocks in Write like any other backpressured sink.
+	// Logging on this path would make the bound this watchdog exists to provide
+	// conditional on the logger being drained, which is the exact shape of
+	// problem it was written to avoid.
+	//
+	// It is the daemon's only account of a dropped guest. The host logs why it
+	// stopped feeding one, but from here the guest simply stops, and which of
+	// the two happened is the difference between a slow viewer and a broken
+	// forwarder.
+	go f.log().Warn("closing a stalled SSH channel; its source closed and the copy never drained",
+		"drain_timeout", f.drainTimeout)
 	if f.settledWithin(finished, f.abortGrace) {
 		return
 	}
 	if f.scope == abortConnection {
-		// The expensive step, and the one worth a line on its own: every other
-		// channel on this connection goes with it, undrained.
-		f.log().Warn("stalled SSH channel did not answer CLOSE; cancelling the connection",
-			"abort_grace", f.abortGrace)
 		f.cancel(errSSHChannelDrainStalled)
+		// The expensive step, and the one worth a line of its own: every other
+		// channel on this connection goes with it, undrained. Ordered after the
+		// cancel for the same reason as above.
+		go f.log().Warn("stalled SSH channel did not answer CLOSE; cancelled the connection",
+			"abort_grace", f.abortGrace)
 	}
 }
 

--- a/server/sshforward.go
+++ b/server/sshforward.go
@@ -28,10 +28,11 @@ import (
 	"context"
 	"errors"
 	"io"
-	"log/slog"
 	"sync"
 	"time"
 
+	"github.com/go-kit/kit/metrics"
+	"github.com/go-kit/kit/metrics/provider"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -115,7 +116,7 @@ var errSSHChannelDrainStalled = errors.New("ssh: channel drain stalled after sou
 // returning. Ordinary transport completion first drains received channel data
 // and request tails toward the surviving peer; forced cancellation closes both
 // transports immediately to release blocked opens, requests and writes.
-func forwardSSH(ctx context.Context, downstream, upstream sshPeer, scope sshAbortScope, logger *slog.Logger) error {
+func forwardSSH(ctx context.Context, downstream, upstream sshPeer, scope sshAbortScope, aborts metrics.Counter) error {
 	ctx, cancel := context.WithCancelCause(ctx)
 	defer cancel(nil)
 	draining := make(chan struct{})
@@ -124,7 +125,7 @@ func forwardSSH(ctx context.Context, downstream, upstream sshPeer, scope sshAbor
 		cancel:       cancel,
 		scope:        scope,
 		draining:     draining,
-		logger:       logger,
+		aborts:       aborts,
 		drainTimeout: sshForwardChannelDrainTimeout,
 		abortGrace:   sshForwardChannelAbortGrace,
 	}
@@ -202,7 +203,10 @@ type sshForwarder struct {
 	// exercise a single direction, where nothing else owns that bound.
 	draining <-chan struct{}
 
-	logger *slog.Logger
+	// aborts counts stalled-channel aborts, labelled by how far the escalation
+	// went. A counter rather than a log line because this fires on a goroutine
+	// nothing joins; see abortStalledDirection.
+	aborts metrics.Counter
 
 	// Fields rather than direct reads of the constants above, so tests can run
 	// the watchdog on a timescale that does not dominate the suite.
@@ -441,38 +445,41 @@ func (f sshForwarder) abortStalledDirection(destination ssh.Channel, finished <-
 		cancelledConnection = true
 	}
 
-	// Last, once every bound this function exists to apply has been applied,
-	// and synchronously.
+	// Counted rather than logged, and counted last.
 	//
-	// A slog handler is one more thing that can block — a daemon whose stderr
-	// is a pipe nobody drains blocks in Write like any other backpressured sink
-	// — so logging before the close or the cancel would make those bounds
-	// conditional on the logger being drained, which is the shape of problem
-	// this watchdog was written to prevent. Logging from a goroutine instead
-	// would fix that and buy a worse one: a handler that stays backpressured
-	// leaves one abandoned goroutine per stall, and established channels are
-	// deliberately uncapped. Placed here it holds the watchdog's own goroutine,
-	// which has finished its work and was about to exit anyway, and adds
-	// nothing that was not already there.
+	// Every logging shape was wrong here. Writing before the close or the
+	// cancel makes those bounds conditional on the handler draining, which is
+	// the problem this watchdog exists to prevent. Writing from a goroutine
+	// abandons one per stall when the handler stays backpressured. Writing
+	// synchronously here abandons the watchdog's own goroutine instead — it is
+	// joined by nothing, so "it was about to exit anyway" is precisely what
+	// stops being true — and established channels are deliberately uncapped,
+	// so either way a wedged handler accumulates goroutines for as long as
+	// guests keep stalling.
 	//
-	// This is the daemon's only account of a dropped guest. The host logs why
-	// it stopped feeding one, but from here the guest simply stops, and which
-	// of the two happened is the difference between a slow viewer and a broken
-	// forwarder.
-	f.log().Warn("closed a stalled SSH channel; its source closed and the copy never drained",
-		"drain_timeout", f.drainTimeout,
-		"abort_grace", f.abortGrace,
-		"cancelled_connection", cancelledConnection)
+	// A counter has none of those failure modes: it cannot block, it retains
+	// nothing, and it is already how this package reports what it is doing.
+	// What it gives up is the per-event detail a log line would carry. For an
+	// abortConnection stall that detail survives anyway — the cancel surfaces
+	// as errSSHChannelDrainStalled on forwardSSH's return, which serveStock
+	// already logs — and for abortChannel the rate is what there is.
+	escalation := "channel"
+	if cancelledConnection {
+		escalation = "connection"
+	}
+	f.abortCounter().With("escalation", escalation).Add(1)
 }
 
-// log is nil-safe so that every way of building a forwarder, including test
-// literals, can escalate without arranging a logger first.
-func (f sshForwarder) log() *slog.Logger {
-	if f.logger == nil {
-		return slog.New(slog.DiscardHandler)
+// abortCounter is nil-safe so that every way of building a forwarder,
+// including test literals, can escalate without arranging instruments first.
+func (f sshForwarder) abortCounter() metrics.Counter {
+	if f.aborts == nil {
+		return discardCounter
 	}
-	return f.logger
+	return f.aborts
 }
+
+var discardCounter = provider.NewDiscardProvider().NewCounter("")
 
 // settledWithin reports whether this direction finished, the connection began
 // draining, or the context was cancelled before timeout elapsed — the three

--- a/server/sshforward.go
+++ b/server/sshforward.go
@@ -28,6 +28,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"log/slog"
 	"sync"
 	"time"
 
@@ -114,7 +115,7 @@ var errSSHChannelDrainStalled = errors.New("ssh: channel drain stalled after sou
 // returning. Ordinary transport completion first drains received channel data
 // and request tails toward the surviving peer; forced cancellation closes both
 // transports immediately to release blocked opens, requests and writes.
-func forwardSSH(ctx context.Context, downstream, upstream sshPeer, scope sshAbortScope) error {
+func forwardSSH(ctx context.Context, downstream, upstream sshPeer, scope sshAbortScope, logger *slog.Logger) error {
 	ctx, cancel := context.WithCancelCause(ctx)
 	defer cancel(nil)
 	draining := make(chan struct{})
@@ -123,6 +124,7 @@ func forwardSSH(ctx context.Context, downstream, upstream sshPeer, scope sshAbor
 		cancel:       cancel,
 		scope:        scope,
 		draining:     draining,
+		logger:       logger,
 		drainTimeout: sshForwardChannelDrainTimeout,
 		abortGrace:   sshForwardChannelAbortGrace,
 	}
@@ -199,6 +201,8 @@ type sshForwarder struct {
 	// hands the stalled-channel bound over to forwardSSH. Nil in tests that
 	// exercise a single direction, where nothing else owns that bound.
 	draining <-chan struct{}
+
+	logger *slog.Logger
 
 	// Fields rather than direct reads of the constants above, so tests can run
 	// the watchdog on a timescale that does not dominate the suite.
@@ -373,13 +377,20 @@ type sshForwardChannel struct {
 func (f sshForwarder) channelDirection(destination, source *sshForwardChannel, requests <-chan *ssh.Request) {
 	finished := make(chan struct{})
 	defer close(finished)
-	sourceClosed := make(chan struct{})
-	go f.abortStalledDirection(destination, sourceClosed, finished)
+
+	// Armed on source closure rather than started with the direction. The
+	// watchdog has nothing to do until then, and a daemon carries two
+	// directions for every live channel: starting eagerly parks that many
+	// goroutines on a select, for the whole life of each channel, against a
+	// case that almost never arrives. requests calls this from inside its own
+	// loop, so finished is still open when it runs.
+	armWatchdog := sync.OnceFunc(func() {
+		go f.abortStalledDirection(destination, finished)
+	})
 
 	var streams sync.WaitGroup
 	streams.Go(func() { copySSHChannel(destination, source) })
-	f.requests(sshChannelRequestSender{destination}, requests,
-		sync.OnceFunc(func() { close(sourceClosed) }),
+	f.requests(sshChannelRequestSender{destination}, requests, armWatchdog,
 		func() { _ = destination.Close() }, sshRequestAbortGrace, &source.replies)
 	streams.Wait()
 	// The source may send success and CLOSE back-to-back. Its reply worker
@@ -389,8 +400,9 @@ func (f sshForwarder) channelDirection(destination, source *sshForwardChannel, r
 	_ = destination.Close()
 }
 
-// abortStalledDirection releases a direction whose source has closed but whose
-// destination has stopped accepting bytes.
+// abortStalledDirection releases a direction whose destination has stopped
+// accepting bytes. channelDirection arms it once the source has closed, so
+// reaching here already means that has happened.
 //
 // It is a watchdog rather than a step in the teardown because every step of
 // that teardown is itself a transport write a stalled peer can block. Close
@@ -411,19 +423,16 @@ func (f sshForwarder) channelDirection(destination, source *sshForwardChannel, r
 // armed within moments of each other and, before this, ran on identical
 // timeouts — and the winner decides which error the shutdown reports. The
 // transport's is the one callers are contracted to see.
-func (f sshForwarder) abortStalledDirection(destination ssh.Channel, sourceClosed, finished <-chan struct{}) {
-	select {
-	case <-finished:
-		return
-	case <-f.ctx.Done():
-		return
-	case <-f.draining:
-		return
-	case <-sourceClosed:
-	}
+func (f sshForwarder) abortStalledDirection(destination ssh.Channel, finished <-chan struct{}) {
 	if f.settledWithin(finished, f.drainTimeout) {
 		return
 	}
+	// The daemon's only account of a dropped guest: the host logs why it
+	// stopped feeding one, but from here the guest simply stops, and which of
+	// the two happened is the difference between a slow viewer and a broken
+	// forwarder.
+	f.log().Warn("closing a stalled SSH channel; its source closed and the copy never drained",
+		"drain_timeout", f.drainTimeout)
 	// In its own goroutine, for the reason above. A write blocked on an
 	// exhausted window does not hold the channel's write mutex, so this is
 	// enough whenever the peer is still reading its socket: it answers the
@@ -433,8 +442,21 @@ func (f sshForwarder) abortStalledDirection(destination ssh.Channel, sourceClose
 		return
 	}
 	if f.scope == abortConnection {
+		// The expensive step, and the one worth a line on its own: every other
+		// channel on this connection goes with it, undrained.
+		f.log().Warn("stalled SSH channel did not answer CLOSE; cancelling the connection",
+			"abort_grace", f.abortGrace)
 		f.cancel(errSSHChannelDrainStalled)
 	}
+}
+
+// log is nil-safe so that every way of building a forwarder, including test
+// literals, can escalate without arranging a logger first.
+func (f sshForwarder) log() *slog.Logger {
+	if f.logger == nil {
+		return slog.New(slog.DiscardHandler)
+	}
+	return f.logger
 }
 
 // settledWithin reports whether this direction finished, the connection began

--- a/server/sshforward_stockclient_test.go
+++ b/server/sshforward_stockclient_test.go
@@ -101,7 +101,7 @@ func forwardTestStockClientHost(t *testing.T) (string, sshPeer) {
 			return
 		}
 		// A stock OpenSSH client is a guest, so its connection is the abort unit.
-		_ = forwardSSH(ctx, sshPeer{serverConn, channels, requests}, upstream, abortConnection)
+		_ = forwardSSH(ctx, sshPeer{serverConn, channels, requests}, upstream, abortConnection, discardLogger())
 	}()
 
 	return listener.Addr().String(), host

--- a/server/sshforward_stockclient_test.go
+++ b/server/sshforward_stockclient_test.go
@@ -101,7 +101,7 @@ func forwardTestStockClientHost(t *testing.T) (string, sshPeer) {
 			return
 		}
 		// A stock OpenSSH client is a guest, so its connection is the abort unit.
-		_ = forwardSSH(ctx, sshPeer{serverConn, channels, requests}, upstream, abortConnection, discardLogger())
+		_ = forwardSSH(ctx, sshPeer{serverConn, channels, requests}, upstream, abortConnection, discardCounter)
 	}()
 
 	return listener.Addr().String(), host

--- a/server/sshforward_test.go
+++ b/server/sshforward_test.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 	"net"
 	"slices"
 	"strings"
@@ -18,6 +17,7 @@ import (
 	"testing/synctest"
 	"time"
 
+	"github.com/go-kit/kit/metrics"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
 )
@@ -108,7 +108,7 @@ func forwardTestProxy(t *testing.T) (sshPeer, sshPeer, context.CancelFunc, <-cha
 	stopped := make(chan struct{})
 	go func() {
 		defer close(stopped)
-		done <- forwardSSH(ctx, downstream, upstream, abortConnection, discardLogger())
+		done <- forwardSSH(ctx, downstream, upstream, abortConnection, discardCounter)
 	}()
 	t.Cleanup(func() {
 		cancel()
@@ -1169,7 +1169,7 @@ func TestSSHForwardSuccessReplyBeforePeerClose(t *testing.T) {
 			}
 			ctx, cancel := context.WithCancel(context.Background())
 			done := make(chan error, 1)
-			go func() { done <- forwardSSH(ctx, downstream, upstream, abortConnection, discardLogger()) }()
+			go func() { done <- forwardSSH(ctx, downstream, upstream, abortConnection, discardCounter) }()
 			t.Cleanup(func() { cancel(); _ = forwardTestReceive(t, done) })
 			a, ar, b, br := forwardTestChannel(t, origin, destination)
 			type response struct {
@@ -1588,8 +1588,6 @@ func forwardTestDirection(t *testing.T, gate *channelGate) (destination, source 
 		func() { _ = producerNear.Close() }
 }
 
-func discardLogger() *slog.Logger { return slog.New(slog.DiscardHandler) }
-
 // newTestForwarder builds a forwarder whose cancel is observable and whose
 // timers are short enough to run in a test.
 func newTestForwarder(t *testing.T, scope sshAbortScope, cancelled chan<- error) sshForwarder {
@@ -1719,35 +1717,46 @@ func TestChannelDirectionYieldsAStalledChannelToTheTransportDrain(t *testing.T) 
 	gate.releaseAll()
 }
 
-// syncBuffer collects log output written from the watchdog's goroutine.
-type syncBuffer struct {
-	mu  sync.Mutex
-	buf []byte
+// recordingCounter records Add calls per label set, so a test can assert which
+// series an abort landed in. The zero value is unusable; use newRecordingCounter.
+type recordingCounter struct {
+	mu     *sync.Mutex
+	counts map[string]float64
+	key    string
 }
 
-func (s *syncBuffer) Write(p []byte) (int, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.buf = append(s.buf, p...)
-	return len(p), nil
+func newRecordingCounter() *recordingCounter {
+	return &recordingCounter{mu: new(sync.Mutex), counts: map[string]float64{}}
 }
 
-func (s *syncBuffer) String() string {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return string(s.buf)
+// With returns a view sharing this counter's state, keyed by its label values.
+func (c *recordingCounter) With(labelValues ...string) metrics.Counter {
+	return &recordingCounter{mu: c.mu, counts: c.counts, key: strings.Join(labelValues, "=")}
 }
 
-// The abort has to say so, and has to say whether it took the connection with
-// it. From the daemon's side a dropped guest is otherwise indistinguishable
-// from one that hung up: the host logs why it stopped feeding a guest, but
-// nothing here recorded that the forwarder then closed the channel, or that
-// every other channel on that connection went down undrained behind it.
-func TestChannelDirectionLogsBothEscalationSteps(t *testing.T) {
-	var logs syncBuffer
+func (c *recordingCounter) Add(delta float64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.counts[c.key] += delta
+}
+
+func (c *recordingCounter) value(key string) float64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.counts[key]
+}
+
+// The abort has to be recorded, and has to record whether it took the
+// connection with it. From the daemon's side a dropped guest is otherwise
+// indistinguishable from one that hung up: the host logs why it stopped
+// feeding a guest, but nothing here counted that the forwarder then closed the
+// channel, or that every other channel on that connection went down undrained
+// behind it.
+func TestChannelDirectionCountsAnAbortAndItsEscalation(t *testing.T) {
+	aborts := newRecordingCounter()
 	cancelled := make(chan error, 1)
 	f := newTestForwarder(t, abortConnection, cancelled)
-	f.logger = slog.New(slog.NewTextHandler(&logs, nil))
+	f.aborts = aborts
 
 	gate := newChannelGate()
 	gate.write = make(chan struct{})
@@ -1766,15 +1775,47 @@ func TestChannelDirectionLogsBothEscalationSteps(t *testing.T) {
 		t.Fatal("a stalled direction was never aborted")
 	}
 
-	// Waited for, not read once: the line is written after the cancel that this
-	// test observes, on the same goroutine, so receiving the cancel says
-	// nothing about whether the line has landed yet.
+	// Waited for, not read once: the counter is incremented after the cancel
+	// this test observes, on the same goroutine, so receiving the cancel says
+	// nothing about whether the increment has happened yet.
 	require.Eventually(t, func() bool {
-		return strings.Contains(logs.String(), "closed a stalled SSH channel")
+		return aborts.value("escalation=connection") == 1
 	}, 5*time.Second, time.Millisecond,
-		"closing a stalled channel left no trace in the daemon log")
-	require.Contains(t, logs.String(), "cancelled_connection=true",
-		"taking a whole connection down left no trace in the daemon log")
+		"a stalled channel that took its connection down was not counted")
+	require.Zero(t, aborts.value("escalation=channel"),
+		"an abort that cancelled the connection must not also count as channel-only")
+
+	gate.releaseAll()
+}
+
+// The same abort on a host's connection stops at the channel, and is counted as
+// such: the scope is the whole reason this distinction exists, and a counter
+// that collapsed it would report a session-ending event and a routine one as
+// the same thing.
+func TestChannelDirectionCountsAChannelScopedAbortSeparately(t *testing.T) {
+	aborts := newRecordingCounter()
+	cancelled := make(chan error, 1)
+	f := newTestForwarder(t, abortChannel, cancelled)
+	f.aborts = aborts
+
+	gate := newChannelGate()
+	gate.write = make(chan struct{})
+	destination, source, requests, closeSource := forwardTestDirection(t, gate)
+
+	go f.channelDirection(destination, source, requests)
+	closeSource()
+	close(requests)
+
+	require.Eventually(t, func() bool {
+		return aborts.value("escalation=channel") == 1
+	}, 5*time.Second, time.Millisecond, "a channel-scoped abort was not counted")
+
+	select {
+	case err := <-cancelled:
+		t.Fatalf("a host's connection was cancelled over one stalled channel: %v", err)
+	default:
+	}
+	require.Zero(t, aborts.value("escalation=connection"))
 
 	gate.releaseAll()
 }
@@ -1866,7 +1907,7 @@ func TestHostScopedAbortLeavesTheTunnelWorking(t *testing.T) {
 	upstream.conn = &gateFirstChannelConn{Conn: upstream.conn, gate: gate}
 
 	forwarded := make(chan error, 1)
-	go func() { forwarded <- forwardSSH(t.Context(), downstream, upstream, abortChannel, discardLogger()) }()
+	go func() { forwarded <- forwardSSH(t.Context(), downstream, upstream, abortChannel, discardCounter) }()
 
 	// The stalled channel: opened first, so it gets the gate.
 	stalled := openTestChannel(t, client)

--- a/server/sshforward_test.go
+++ b/server/sshforward_test.go
@@ -1329,9 +1329,17 @@ func TestSSHForwardAbortCutsBufferedData(t *testing.T) {
 	// Lower bound, and the load-bearing one. Every assertion below is an upper
 	// bound, so without this the case passes when nothing ever moved: a.Close()
 	// makes Write return 0, ReadAll returns 0, and 0 is under every ceiling.
-	// Waiting for two windows to be accepted means the forwarder has drained a
-	// window out of a and pushed it at b, so there is real data in the pipeline
-	// to cut.
+	// Passing a full window means the forwarder has drained a window out of a
+	// and pushed it at b, so there is real data in the pipeline to cut.
+	//
+	// Half a window past that, rather than a second whole one. Two windows is
+	// the pipeline's theoretical maximum, and waiting for the maximum makes the
+	// gate a throughput test: under load it lands one 64 KiB chunk short and
+	// fails a case that had in fact filled the pipeline. Measured on macOS at
+	// 3 of 40 runs before the change this test arrived in, and 1 of 40 after,
+	// so it is the gate rather than anything it guards. The margin above one
+	// window is what proves the forwarder is pushing, and half a window is an
+	// unambiguous margin.
 	//
 	// The budget is not ours to choose freely: forwardTestPair puts an absolute
 	// 10s deadline on both transports, so a wait longer than that cannot make
@@ -1339,15 +1347,16 @@ func TestSSHForwardAbortCutsBufferedData(t *testing.T) {
 	// "nothing to cut". Stay well inside it, and watch the writer as well as the
 	// clock — if it stops early the transport or channel ended, which is a
 	// different failure and deserves to say so.
+	const loaded = sshChannelWindow + sshChannelWindow/2
 	gate := time.After(3 * time.Second)
-	for accepted.Load() < 2*sshChannelWindow {
+	for accepted.Load() < loaded {
 		select {
 		case <-writerDone:
 			t.Fatalf("origin stopped writing at %d of the %d bytes the pipeline needs; "+
-				"the channel or transport ended before the abort was armed", accepted.Load(), 2*sshChannelWindow)
+				"the channel or transport ended before the abort was armed", accepted.Load(), loaded)
 		case <-gate:
 			t.Fatalf("only %d of the %d bytes needed entered the forwarding path within the transport budget",
-				accepted.Load(), 2*sshChannelWindow)
+				accepted.Load(), loaded)
 		case <-time.After(time.Millisecond):
 		}
 	}

--- a/server/sshforward_test.go
+++ b/server/sshforward_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"slices"
 	"strings"
@@ -105,7 +106,10 @@ func forwardTestProxy(t *testing.T) (sshPeer, sshPeer, context.CancelFunc, <-cha
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	stopped := make(chan struct{})
-	go func() { defer close(stopped); done <- forwardSSH(ctx, downstream, upstream, abortConnection) }()
+	go func() {
+		defer close(stopped)
+		done <- forwardSSH(ctx, downstream, upstream, abortConnection, discardLogger())
+	}()
 	t.Cleanup(func() {
 		cancel()
 		select {
@@ -1165,7 +1169,7 @@ func TestSSHForwardSuccessReplyBeforePeerClose(t *testing.T) {
 			}
 			ctx, cancel := context.WithCancel(context.Background())
 			done := make(chan error, 1)
-			go func() { done <- forwardSSH(ctx, downstream, upstream, abortConnection) }()
+			go func() { done <- forwardSSH(ctx, downstream, upstream, abortConnection, discardLogger()) }()
 			t.Cleanup(func() { cancel(); _ = forwardTestReceive(t, done) })
 			a, ar, b, br := forwardTestChannel(t, origin, destination)
 			type response struct {
@@ -1575,6 +1579,8 @@ func forwardTestDirection(t *testing.T, gate *channelGate) (destination, source 
 		func() { _ = producerNear.Close() }
 }
 
+func discardLogger() *slog.Logger { return slog.New(slog.DiscardHandler) }
+
 // newTestForwarder builds a forwarder whose cancel is observable and whose
 // timers are short enough to run in a test.
 func newTestForwarder(t *testing.T, scope sshAbortScope, cancelled chan<- error) sshForwarder {
@@ -1704,6 +1710,60 @@ func TestChannelDirectionYieldsAStalledChannelToTheTransportDrain(t *testing.T) 
 	gate.releaseAll()
 }
 
+// syncBuffer collects log output written from the watchdog's goroutine.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf []byte
+}
+
+func (s *syncBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.buf = append(s.buf, p...)
+	return len(p), nil
+}
+
+func (s *syncBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return string(s.buf)
+}
+
+// Both escalation steps have to say so. From the daemon's side a dropped guest
+// is otherwise indistinguishable from one that hung up: the host logs why it
+// stopped feeding a guest, but nothing here recorded that the forwarder then
+// closed the channel, or that it took the whole connection down behind it.
+func TestChannelDirectionLogsBothEscalationSteps(t *testing.T) {
+	var logs syncBuffer
+	cancelled := make(chan error, 1)
+	f := newTestForwarder(t, abortConnection, cancelled)
+	f.logger = slog.New(slog.NewTextHandler(&logs, nil))
+
+	gate := newChannelGate()
+	gate.write = make(chan struct{})
+	// Close gated too, so the peer never answers and the grace has to expire.
+	gate.close = make(chan struct{})
+	destination, source, requests, closeSource := forwardTestDirection(t, gate)
+
+	go f.channelDirection(destination, source, requests)
+	closeSource()
+	close(requests)
+
+	select {
+	case err := <-cancelled:
+		require.ErrorIs(t, err, errSSHChannelDrainStalled)
+	case <-time.After(10 * time.Second):
+		t.Fatal("a stalled direction was never aborted")
+	}
+
+	require.Contains(t, logs.String(), "closing a stalled SSH channel",
+		"closing a stalled channel left no trace in the daemon log")
+	require.Contains(t, logs.String(), "cancelling the connection",
+		"taking a whole connection down left no trace in the daemon log")
+
+	gate.releaseAll()
+}
+
 // gateFirstChannelConn gates the first channel opened on this connection and
 // leaves every later one alone, so one stalled channel and one healthy channel
 // share a transport.
@@ -1791,7 +1851,7 @@ func TestHostScopedAbortLeavesTheTunnelWorking(t *testing.T) {
 	upstream.conn = &gateFirstChannelConn{Conn: upstream.conn, gate: gate}
 
 	forwarded := make(chan error, 1)
-	go func() { forwarded <- forwardSSH(t.Context(), downstream, upstream, abortChannel) }()
+	go func() { forwarded <- forwardSSH(t.Context(), downstream, upstream, abortChannel, discardLogger()) }()
 
 	// The stalled channel: opened first, so it gets the gate.
 	stalled := openTestChannel(t, client)

--- a/server/sshforward_test.go
+++ b/server/sshforward_test.go
@@ -1733,6 +1733,10 @@ func (s *syncBuffer) String() string {
 // is otherwise indistinguishable from one that hung up: the host logs why it
 // stopped feeding a guest, but nothing here recorded that the forwarder then
 // closed the channel, or that it took the whole connection down behind it.
+//
+// Waited for rather than read once, because each line is emitted from its own
+// goroutine — the abort must not be able to block behind a logger, so it is
+// started first and reported afterwards.
 func TestChannelDirectionLogsBothEscalationSteps(t *testing.T) {
 	var logs syncBuffer
 	cancelled := make(chan error, 1)
@@ -1756,9 +1760,13 @@ func TestChannelDirectionLogsBothEscalationSteps(t *testing.T) {
 		t.Fatal("a stalled direction was never aborted")
 	}
 
-	require.Contains(t, logs.String(), "closing a stalled SSH channel",
+	require.Eventually(t, func() bool {
+		return strings.Contains(logs.String(), "closing a stalled SSH channel")
+	}, 5*time.Second, time.Millisecond,
 		"closing a stalled channel left no trace in the daemon log")
-	require.Contains(t, logs.String(), "cancelling the connection",
+	require.Eventually(t, func() bool {
+		return strings.Contains(logs.String(), "cancelled the connection")
+	}, 5*time.Second, time.Millisecond,
 		"taking a whole connection down left no trace in the daemon log")
 
 	gate.releaseAll()

--- a/server/sshforward_test.go
+++ b/server/sshforward_test.go
@@ -1738,14 +1738,11 @@ func (s *syncBuffer) String() string {
 	return string(s.buf)
 }
 
-// Both escalation steps have to say so. From the daemon's side a dropped guest
-// is otherwise indistinguishable from one that hung up: the host logs why it
-// stopped feeding a guest, but nothing here recorded that the forwarder then
-// closed the channel, or that it took the whole connection down behind it.
-//
-// Waited for rather than read once, because each line is emitted from its own
-// goroutine — the abort must not be able to block behind a logger, so it is
-// started first and reported afterwards.
+// The abort has to say so, and has to say whether it took the connection with
+// it. From the daemon's side a dropped guest is otherwise indistinguishable
+// from one that hung up: the host logs why it stopped feeding a guest, but
+// nothing here recorded that the forwarder then closed the channel, or that
+// every other channel on that connection went down undrained behind it.
 func TestChannelDirectionLogsBothEscalationSteps(t *testing.T) {
 	var logs syncBuffer
 	cancelled := make(chan error, 1)
@@ -1769,13 +1766,14 @@ func TestChannelDirectionLogsBothEscalationSteps(t *testing.T) {
 		t.Fatal("a stalled direction was never aborted")
 	}
 
+	// Waited for, not read once: the line is written after the cancel that this
+	// test observes, on the same goroutine, so receiving the cancel says
+	// nothing about whether the line has landed yet.
 	require.Eventually(t, func() bool {
-		return strings.Contains(logs.String(), "closing a stalled SSH channel")
+		return strings.Contains(logs.String(), "closed a stalled SSH channel")
 	}, 5*time.Second, time.Millisecond,
 		"closing a stalled channel left no trace in the daemon log")
-	require.Eventually(t, func() bool {
-		return strings.Contains(logs.String(), "cancelled the connection")
-	}, 5*time.Second, time.Millisecond,
+	require.Contains(t, logs.String(), "cancelled_connection=true",
 		"taking a whole connection down left no trace in the daemon log")
 
 	gate.releaseAll()

--- a/server/sshrouting.go
+++ b/server/sshrouting.go
@@ -68,6 +68,12 @@ type routingInstruments struct {
 	// included.
 	authenticatedHost   metrics.Counter
 	authenticatedClient metrics.Counter
+	// stalledChannelAborts counts channels the forwarder had to close because
+	// their source had gone and the destination had stopped reading, labelled
+	// by whether the connection went with them. It is a counter and not a log
+	// line because it is recorded on a watchdog goroutine nothing joins; see
+	// abortStalledDirection.
+	stalledChannelAborts metrics.Counter
 }
 
 func newSSHRoutingInstruments(p provider.Provider) *routingInstruments {
@@ -80,9 +86,13 @@ func newSSHRoutingInstruments(p provider.Provider) *routingInstruments {
 		connectionTimeouts:  p.NewCounter("routing_connection_timeout_count"),
 		authenticatedHost:   authenticated.With("kind", "host"),
 		authenticatedClient: authenticated.With("kind", "client"),
+		stalledChannelAborts: newLabeledCounter(p,
+			"routing_stalled_channel_aborts_count", "escalation"),
 	}
 	inst.authenticatedHost.Add(0) // export both series from startup
 	inst.authenticatedClient.Add(0)
+	inst.stalledChannelAborts.With("escalation", "channel").Add(0)
+	inst.stalledChannelAborts.With("escalation", "connection").Add(0)
 	return inst
 }
 

--- a/server/sshstock.go
+++ b/server/sshstock.go
@@ -234,7 +234,7 @@ func (p *SSHRouting) stockConnection(ctx context.Context, raw net.Conn, inst *ro
 					} else {
 						inst.authenticatedClient.Add(1)
 					}
-					return forwardSSH(ctx, peer, sshPeer{upstream, upstreamChannels, upstreamRequests}, abortScopeFor(clientVersion), p.logger())
+					return forwardSSH(ctx, peer, sshPeer{upstream, upstreamChannels, upstreamRequests}, abortScopeFor(clientVersion), inst.stalledChannelAborts)
 				}
 			}
 		}

--- a/server/sshstock.go
+++ b/server/sshstock.go
@@ -234,7 +234,7 @@ func (p *SSHRouting) stockConnection(ctx context.Context, raw net.Conn, inst *ro
 					} else {
 						inst.authenticatedClient.Add(1)
 					}
-					return forwardSSH(ctx, peer, sshPeer{upstream, upstreamChannels, upstreamRequests}, abortScopeFor(clientVersion))
+					return forwardSSH(ctx, peer, sshPeer{upstream, upstreamChannels, upstreamRequests}, abortScopeFor(clientVersion), p.logger())
 				}
 			}
 		}


### PR DESCRIPTION
Four follow-ups recorded while #533 was in review, none of them blocking it.

## A guest that never received its tail now says so

The fan-out's shutdown flush discarded its error. It is best-effort by design — the deadline expires, the host exits — which is what made the error easy to throw away, and is also why throwing it away is wrong: a guest whose last screenful never arrived looked exactly like output the command never produced. `command` carries the Server's logger for this, which is the one new constructor argument.

## The forwarder's escalation is no longer silent

`abortStalledDirection` closed a stalled channel, and sometimes cancelled the whole connection behind it, without a word. The host logs why it stopped feeding a guest, but from the daemon's side the guest simply stopped — and which of the two happened is the difference between a slow viewer and a broken forwarder.

It reports through `routing_stalled_channel_aborts_count`, labelled by escalation, rather than a log line. Review established that no logging shape works on this path, and the reasoning is worth keeping: the watchdog runs on a goroutine nothing joins, so writing before the abort gates the bound the watchdog exists to provide; writing after it on that goroutine retains the goroutine for as long as a wedged handler stays wedged; and writing from another goroutine just relabels which one leaks. Established channels are uncapped, so any of those accumulates while guests keep stalling.

A counter has none of those failure modes, and `newSSHRoutingInstruments` already exports series from startup this way for authenticated connections. What it gives up is per-event detail. For an `abortConnection` stall that survives anyway — the cancel surfaces as `errSSHChannelDrainStalled` on `forwardSSH`'s return, which `serveStock` already logs — and for `abortChannel` the rate is what there is.

## The watchdog is armed, not started

It was started with every direction and parked on a select for the channel's whole life — two goroutines per live channel against a case that almost never arrives. It is now armed from the source-closure callback, which `requests` invokes from inside its own loop, so `finished` is still open when it runs.

No new test: this changes no behaviour, only how many goroutines sit idle. The existing cases still pin that the watchdog fires after source closure and stays out of a live channel's way. A goroutine-count assertion is the only thing that would observe the difference directly, and it would not survive the mux and copy goroutines moving around it.

## Flush is covered across a multi-chunk backlog

The existing cases queue one small write, so the drain empties the buffer in a single pass. This steps a four-chunk backlog through one write at a time and requires that `Flush` is still waiting after every write that leaves something owed.

The stepping is the point, and two simpler versions were measured and discarded: releasing the backlog at once lets the drain finish before any assertion runs, and checking only after the first write misses an early return later in the backlog. Both passed against a deliberately broken sink.

It guards the contract rather than either mechanism holding it up. The drain publishes idle only on the pass that finds pending empty, and `Flush` re-checks instead of trusting one wake-up; either alone is sufficient, so breaking one still passes and breaking both fails with `Flush returned with 65536 of 262149 bytes delivered`.

## Review fix: the host's flush warning is waited for, under a bound

The same question on the host side has a different answer, because the constraint is different. That warning is written in the output actor's `defer`, which is the actor's return path — `run.Group` cannot finish until it returns, so writing directly would let a blocked handler hang the host's exit and leave `guestFlushTimeout` bounding nothing. Fire-and-forget is not the fix either: Go abandons runnable goroutines at process exit, so the one diagnostic this path produces could be lost, or land after the shutdown lines it should precede, with a perfectly healthy logger.

It is written on its own goroutine and waited for with a 100ms ceiling. Both halves are pinned by tests that fail in opposite directions: the existing case asserts the line is present the moment `Run` returns, which fire-and-forget fails, and a new one gives the handler a `Write` that never returns and requires `Run` to finish anyway, which unbounded waiting fails.

A counter is not the answer here the way it is for the forwarder: this is a once-per-process event carrying an error worth reading, not a rate.

## Unrelated: a flaky gate in TestSSHForwardAbortCutsBufferedData

This failed the macOS job here, and it is not from this branch. The test's lower bound waited for two SSH windows to be accepted — the pipeline's theoretical maximum — which made the gate a throughput test: under load the writer lands one 64 KiB chunk short and the case fails having in fact filled the pipeline.

Measured on macOS: 3 failures in 40 runs at `488072b`, where the test landed, and 1 in 40 at `7b64a59` after #533 merged. Zero in 40 with the gate at a window and a half.

The property the gate establishes is that the forwarder has drained a window out of the origin and is pushing at a destination that will not read. Any margin past one full window shows that; half a window is an unambiguous one. Every assertion it guards is an upper bound measured against what the origin actually wrote, so none of them depend on the threshold.

Happy to split this into its own PR if you would rather not carry it here.

## Verification

`make test` green, zero `FAIL` lines. `io` at 94.1% statement coverage, `server` at 66.8%.

Each new test was checked by reverting the behaviour it names and confirming it fails for that reason.

Two files are not gofmt-clean on master — `io/query_filter.go` and `host/internal/sftp.go` — and neither is touched here. Left alone rather than bundling an unrelated reformat into this diff.
