### PR TITLE
Make the tree gofmt-clean

### DIFF
--- a/cmd/upterm/command/privacy.go
+++ b/cmd/upterm/command/privacy.go
@@ -18,9 +18,10 @@ var (
 // detected CI environments to prevent accidental exposure in build logs.
 //
 // Usage:
-//   upterm host --hide-client-ip              # Explicit flag
-//   UPTERM_HIDE_CLIENT_IP=true upterm host    # Environment variable (auto-bound)
-//   upterm host                               # Auto-detects CI (GitHub Actions, etc.)
+//
+//	upterm host --hide-client-ip              # Explicit flag
+//	UPTERM_HIDE_CLIENT_IP=true upterm host    # Environment variable (auto-bound)
+//	upterm host                               # Auto-detects CI (GitHub Actions, etc.)
 func shouldHideClientIP() bool {
 	// If flag is set (either via CLI flag or via UPTERM_HIDE_CLIENT_IP env var bound by viper)
 	if flagHideClientIP {
@@ -35,15 +36,15 @@ func shouldHideClientIP() bool {
 // by checking for common CI environment variables.
 func isCI() bool {
 	ciEnvVars := []string{
-		"CI",             // Generic CI indicator (GitHub Actions, GitLab CI, etc.)
-		"GITHUB_ACTIONS", // GitHub Actions
-		"GITLAB_CI",      // GitLab CI
-		"CIRCLECI",       // CircleCI
-		"TRAVIS",         // Travis CI
-		"JENKINS_URL",    // Jenkins
-		"BUILDKITE",      // Buildkite
-		"TF_BUILD",       // Azure Pipelines
-		"TEAMCITY_VERSION", // TeamCity
+		"CI",                     // Generic CI indicator (GitHub Actions, GitLab CI, etc.)
+		"GITHUB_ACTIONS",         // GitHub Actions
+		"GITLAB_CI",              // GitLab CI
+		"CIRCLECI",               // CircleCI
+		"TRAVIS",                 // Travis CI
+		"JENKINS_URL",            // Jenkins
+		"BUILDKITE",              // Buildkite
+		"TF_BUILD",               // Azure Pipelines
+		"TEAMCITY_VERSION",       // TeamCity
 		"BITBUCKET_BUILD_NUMBER", // Bitbucket Pipelines
 	}
 

--- a/host/internal/sftp.go
+++ b/host/internal/sftp.go
@@ -18,7 +18,7 @@ import (
 
 // SFTPSession tracks permission state for a single SFTP session
 type SFTPSession struct {
-	readOnly          bool                      // Only allow downloads (no upload/delete)
+	readOnly          bool                       // Only allow downloads (no upload/delete)
 	permissionChecker hostsftp.PermissionChecker // Optional: prompts user for permission (nil = auto-allow)
 	clientInfo        hostsftp.ClientInfo        // Client information for permission dialogs
 }

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -262,7 +262,6 @@ func extractScpPortFlag(sshCmd string) string {
 	return ""
 }
 
-
 // TestSync validates bidirectional real-time PTY sync between host and client.
 func TestSync(t *testing.T) {
 	h := newTestHarness(t, 200)

--- a/io/query_filter.go
+++ b/io/query_filter.go
@@ -27,17 +27,17 @@ type TerminalQueryFilter struct {
 type queryFilterState int
 
 const (
-	qfStateNormal      queryFilterState = iota
-	qfStateEsc                          // saw ESC
-	qfStateCSI                          // saw ESC [
-	qfStateCSIParam                     // parsing CSI parameters
-	qfStateOSC                          // saw ESC ]
-	qfStateOSCParam                     // saw OSC number
-	qfStateOSCSemi                      // saw OSC number ;
-	qfStateOSCQuery                     // saw OSC N ; ? (query for color)
-	qfStateOSCQueryEsc                  // saw ESC in OSC query (possible ST)
-	qfStateOSCContent                   // saw OSC N ; <non-?> (not a query, pass through)
-	qfStateOSCContentEsc                // saw ESC in OSC content (possible ST)
+	qfStateNormal        queryFilterState = iota
+	qfStateEsc                            // saw ESC
+	qfStateCSI                            // saw ESC [
+	qfStateCSIParam                       // parsing CSI parameters
+	qfStateOSC                            // saw ESC ]
+	qfStateOSCParam                       // saw OSC number
+	qfStateOSCSemi                        // saw OSC number ;
+	qfStateOSCQuery                       // saw OSC N ; ? (query for color)
+	qfStateOSCQueryEsc                    // saw ESC in OSC query (possible ST)
+	qfStateOSCContent                     // saw OSC N ; <non-?> (not a query, pass through)
+	qfStateOSCContentEsc                  // saw ESC in OSC content (possible ST)
 )
 
 // NewTerminalQueryFilter creates a filter that removes terminal query


### PR DESCRIPTION
Four files had drifted out of `gofmt`: comment alignment in `io/query_filter.go` and `host/internal/sftp.go`, a doc-comment code block in `cmd/upterm/command/privacy.go` that predates gofmt's tabbed-block rule, and a stray blank line in `internal/e2e/e2e_test.go`.

`git diff --ignore-all-space` is empty apart from blank-line placement, so nothing here is a content change. `go build ./...`, `go vet ./...` and `make test` are all clean.

Two of these turned up while checking files a review on #534 had flagged. I swept the whole repo rather than fixing those two, since a partially formatted tree is what let the others accumulate unnoticed — CI runs `go vet`, which does not check formatting.
