### PR TITLE
Fix functional test subtest nesting

### DIFF
--- a/ftests/ftests_test.go
+++ b/ftests/ftests_test.go
@@ -198,12 +198,12 @@ func (suite *FtestSuite) runTestCategory(testCases []FtestCase) {
 
 	for _, protocol := range protocols {
 		suite.T().Run(protocol, func(t *testing.T) {
-			suite.runTestsForProtocol(protocol, testCases)
+			suite.runTestsForProtocol(t, protocol, testCases)
 		})
 	}
 }
 
-func (suite *FtestSuite) runTestsForProtocol(protocol string, testCases []FtestCase) {
+func (suite *FtestSuite) runTestsForProtocol(t *testing.T, protocol string, testCases []FtestCase) {
 	topologies := []struct {
 		name      string
 		hostURL   string
@@ -222,7 +222,7 @@ func (suite *FtestSuite) runTestsForProtocol(protocol string, testCases []FtestC
 	}
 
 	for _, topo := range topologies {
-		suite.T().Run(topo.name, func(t *testing.T) {
+		t.Run(topo.name, func(t *testing.T) {
 			for _, testFunc := range testCases {
 				testName := funcName(testFunc)
 				t.Run(testName, func(t *testing.T) {


### PR DESCRIPTION
Targeted functional-test filters such as `TestEmbedded/TestProxy/ssh/singleNode/testProxyStockSSHClientTrailingOutput` previously reported success without running the requested case because topology subtests were registered as siblings of the protocol subtest.

Pass the protocol subtest's `*testing.T` into `runTestsForProtocol` and use it to register topologies. This restores the category/protocol/topology/case hierarchy while preserving the existing test matrix and leaf parallelism.

Fixes #531.

Validation:
- Reproduced the false success before the fix using JSON test events; the requested leaf never ran.
- Ran the exact filter with `-count=1 -race -json` after the fix and verified that the requested leaf ran and passed.
- `make test GO_TEST_FLAGS=-json` passed with the race detector. All 173 embedded test nodes match the baseline after correcting their paths, with 30 cases registered in each of the four protocol/topology combinations.
- Consul tests were skipped because Consul was unavailable locally.
