### PR TITLE
Fix Screen and tmux terminal output corruption

### DIFF
--- a/host/internal/server.go
+++ b/host/internal/server.go
@@ -176,7 +176,7 @@ func (s *Server) ServeWithContext(ctx context.Context, l net.Listener) error {
 				return true
 			},
 			ChannelHandlers: map[string]gssh.ChannelHandler{
-				"session":      gssh.DefaultSessionHandler,
+				"session":      rawSessionHandler,
 				"direct-tcpip": gssh.DirectTCPIPHandler,
 			},
 			SubsystemHandlers: subsystemHandlers,

--- a/host/internal/server_output_unix_test.go
+++ b/host/internal/server_output_unix_test.go
@@ -1,0 +1,122 @@
+//go:build !windows
+
+package internal
+
+import (
+	"bufio"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"io"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/olebedev/emitter"
+	"github.com/owenthereal/upterm/server"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+)
+
+// Screen uses LF to move down without changing the cursor column. Rewriting
+// it to CRLF loses indentation on redraw (#288) and misplaces pane output
+// (#278). Exercise the real host SSH server: a fake Session.Write would hide
+// the SSH library's additional newline processing.
+func TestServerPreservesPTYOutput(t *testing.T) {
+	const output = "\x1b[H\x1b[2JHELLO   \nHELLO\r\n\x1b[12;9Hpane\nnext\r\r\n\x04"
+	command := []string{"sh", "-c", `stty -echo -opost; printf READY; IFS= read -r line; printf '\033[H\033[2JHELLO   \nHELLO\r\n\033[12;9Hpane\nnext\r\r\n\004'; IFS= read -r line`}
+
+	for _, mode := range []string{"shared replay", "shared live", "forced command"} {
+		t.Run(mode, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			stdin, input, err := os.Pipe()
+			require.NoError(t, err)
+			defer stdin.Close()
+			defer input.Close()
+			stdout, hostOutput, err := os.Pipe()
+			require.NoError(t, err)
+			defer stdout.Close()
+			defer hostOutput.Close()
+			require.NoError(t, stdout.SetReadDeadline(time.Now().Add(10*time.Second)))
+
+			_, key, err := ed25519.GenerateKey(rand.Reader)
+			require.NoError(t, err)
+			signer, err := ssh.NewSignerFromKey(key)
+			require.NoError(t, err)
+			cert := &server.UserCertSigner{
+				User: "guest", SessionID: "output-test",
+				AuthRequest: &server.AuthRequest{AuthorizedKey: ssh.MarshalAuthorizedKey(signer.PublicKey())},
+			}
+			guestSigner, err := cert.SignCert(signer)
+			require.NoError(t, err)
+
+			srv := &Server{
+				Command: command, Signers: []ssh.Signer{signer},
+				Stdin: stdin, Stdout: hostOutput, EventEmitter: emitter.New(1),
+				KeepAliveDuration: time.Hour, Logger: discardLogger(),
+				ForceForwardingInputForTesting: true,
+			}
+			if mode == "forced command" {
+				srv.ForceCommand = command
+			}
+			ln, err := net.Listen("tcp", "127.0.0.1:0")
+			require.NoError(t, err)
+			defer ln.Close()
+			done := make(chan error, 1)
+			go func() { done <- srv.ServeWithContext(ctx, ln) }()
+			defer func() {
+				cancel()
+				select {
+				case <-done:
+				case <-time.After(10 * time.Second):
+					t.Error("host server did not stop")
+				}
+			}()
+
+			ready := make([]byte, len("READY"))
+			_, err = io.ReadFull(stdout, ready)
+			require.NoError(t, err)
+			require.Equal(t, "READY", string(ready))
+			if mode == "shared replay" {
+				_, err = io.WriteString(input, "\n")
+				require.NoError(t, err)
+				got, err := bufio.NewReader(stdout).ReadString('\x04')
+				require.NoError(t, err)
+				require.Equal(t, output, got)
+			}
+
+			raw, err := net.DialTimeout("tcp", ln.Addr().String(), 10*time.Second)
+			require.NoError(t, err)
+			defer raw.Close()
+			require.NoError(t, raw.SetDeadline(time.Now().Add(10*time.Second)))
+			conn, chans, reqs, err := ssh.NewClientConn(raw, ln.Addr().String(), &ssh.ClientConfig{
+				User: "guest", Auth: []ssh.AuthMethod{ssh.PublicKeys(guestSigner)},
+				HostKeyCallback: ssh.FixedHostKey(signer.PublicKey()),
+			})
+			require.NoError(t, err)
+			client := ssh.NewClient(conn, chans, reqs)
+			defer client.Close()
+			sess, err := client.NewSession()
+			require.NoError(t, err)
+			defer sess.Close()
+			require.NoError(t, sess.RequestPty("xterm", 24, 80, ssh.TerminalModes{}))
+			guestInput, err := sess.StdinPipe()
+			require.NoError(t, err)
+			guestOutput, err := sess.StdoutPipe()
+			require.NoError(t, err)
+			require.NoError(t, sess.Shell())
+			_, err = io.ReadFull(guestOutput, ready)
+			require.NoError(t, err)
+			require.Equal(t, "READY", string(ready))
+			if mode != "shared replay" {
+				_, err = io.WriteString(guestInput, "\n")
+				require.NoError(t, err)
+			}
+			got, err := bufio.NewReader(guestOutput).ReadString('\x04')
+			require.NoError(t, err)
+			require.Equal(t, output, got, "SSH must preserve the bytes produced by the PTY")
+		})
+	}
+}

--- a/host/internal/server_output_unix_test.go
+++ b/host/internal/server_output_unix_test.go
@@ -33,12 +33,12 @@ func TestServerPreservesPTYOutput(t *testing.T) {
 			defer cancel()
 			stdin, input, err := os.Pipe()
 			require.NoError(t, err)
-			defer stdin.Close()
-			defer input.Close()
+			defer func() { _ = stdin.Close() }()
+			defer func() { _ = input.Close() }()
 			stdout, hostOutput, err := os.Pipe()
 			require.NoError(t, err)
-			defer stdout.Close()
-			defer hostOutput.Close()
+			defer func() { _ = stdout.Close() }()
+			defer func() { _ = hostOutput.Close() }()
 			require.NoError(t, stdout.SetReadDeadline(time.Now().Add(10*time.Second)))
 
 			_, key, err := ed25519.GenerateKey(rand.Reader)
@@ -63,7 +63,7 @@ func TestServerPreservesPTYOutput(t *testing.T) {
 			}
 			ln, err := net.Listen("tcp", "127.0.0.1:0")
 			require.NoError(t, err)
-			defer ln.Close()
+			defer func() { _ = ln.Close() }()
 			done := make(chan error, 1)
 			go func() { done <- srv.ServeWithContext(ctx, ln) }()
 			defer func() {
@@ -89,7 +89,7 @@ func TestServerPreservesPTYOutput(t *testing.T) {
 
 			raw, err := net.DialTimeout("tcp", ln.Addr().String(), 10*time.Second)
 			require.NoError(t, err)
-			defer raw.Close()
+			defer func() { _ = raw.Close() }()
 			require.NoError(t, raw.SetDeadline(time.Now().Add(10*time.Second)))
 			conn, chans, reqs, err := ssh.NewClientConn(raw, ln.Addr().String(), &ssh.ClientConfig{
 				User: "guest", Auth: []ssh.AuthMethod{ssh.PublicKeys(guestSigner)},
@@ -97,10 +97,10 @@ func TestServerPreservesPTYOutput(t *testing.T) {
 			})
 			require.NoError(t, err)
 			client := ssh.NewClient(conn, chans, reqs)
-			defer client.Close()
+			defer func() { _ = client.Close() }()
 			sess, err := client.NewSession()
 			require.NoError(t, err)
-			defer sess.Close()
+			defer func() { _ = sess.Close() }()
 			require.NoError(t, sess.RequestPty("xterm", 24, 80, ssh.TerminalModes{}))
 			guestInput, err := sess.StdinPipe()
 			require.NoError(t, err)

--- a/host/internal/ssh_session.go
+++ b/host/internal/ssh_session.go
@@ -1,0 +1,48 @@
+package internal
+
+import (
+	gssh "charm.land/ssh"
+	"golang.org/x/crypto/ssh"
+)
+
+// rawSessionHandler keeps the SSH library's PTY request and window handling,
+// but sends output directly to the channel. Upterm already owns a real PTY;
+// the library's emulated PTY writer would turn LF into CRLF a second time,
+// breaking cursor positioning in programs such as GNU Screen (#288, #278).
+func rawSessionHandler(srv *gssh.Server, conn *ssh.ServerConn, newChan ssh.NewChannel, ctx gssh.Context) {
+	channel := &sessionChannel{NewChannel: newChan}
+	// Only the session configuration is needed by DefaultSessionHandler. Build
+	// it per channel so the captured output cannot leak to another session on
+	// the same connection, and do not copy the running server's mutexes.
+	sessionServer := &gssh.Server{
+		Handler: func(sess gssh.Session) {
+			srv.Handler(&rawSession{Session: sess, channel: channel.channel})
+		},
+		PtyCallback:            srv.PtyCallback,
+		PtyHandler:             srv.PtyHandler,
+		SessionRequestCallback: srv.SessionRequestCallback,
+		SubsystemHandlers:      srv.SubsystemHandlers,
+	}
+	gssh.DefaultSessionHandler(sessionServer, conn, channel, ctx)
+}
+
+// Capture the underlying channel when DefaultSessionHandler accepts it.
+type sessionChannel struct {
+	ssh.NewChannel
+	channel ssh.Channel
+}
+
+func (c *sessionChannel) Accept() (ssh.Channel, <-chan *ssh.Request, error) {
+	channel, requests, err := c.NewChannel.Accept()
+	c.channel = channel
+	return channel, requests, err
+}
+
+type rawSession struct {
+	gssh.Session
+	channel ssh.Channel
+}
+
+func (s *rawSession) Write(p []byte) (int, error) {
+	return s.channel.Write(p)
+}

--- a/host/internal/ssh_session.go
+++ b/host/internal/ssh_session.go
@@ -11,9 +11,10 @@ import (
 // breaking cursor positioning in programs such as GNU Screen (#288, #278).
 func rawSessionHandler(srv *gssh.Server, conn *ssh.ServerConn, newChan ssh.NewChannel, ctx gssh.Context) {
 	channel := &sessionChannel{NewChannel: newChan}
-	// Only the session configuration is needed by DefaultSessionHandler. Build
-	// it per channel so the captured output cannot leak to another session on
-	// the same connection, and do not copy the running server's mutexes.
+	// These are the fields DefaultSessionHandler reads in charm.land/ssh v0.4.3;
+	// recheck them when upgrading the dependency. Build this configuration per
+	// channel so the captured output cannot leak to another session on the same
+	// connection, and do not copy the running server's mutexes.
 	sessionServer := &gssh.Server{
 		Handler: func(sess gssh.Session) {
 			srv.Handler(&rawSession{Session: sess, channel: channel.channel})

--- a/host/internal/ssh_session_test.go
+++ b/host/internal/ssh_session_test.go
@@ -36,14 +36,14 @@ func TestRawSessionOutput(t *testing.T) {
 
 	raw, err := net.DialTimeout("tcp", ln.Addr().String(), 10*time.Second)
 	require.NoError(t, err)
-	defer raw.Close()
+	defer func() { _ = raw.Close() }()
 	require.NoError(t, raw.SetDeadline(time.Now().Add(10*time.Second)))
 	conn, chans, reqs, err := ssh.NewClientConn(raw, ln.Addr().String(), &ssh.ClientConfig{
 		User: "guest", HostKeyCallback: ssh.FixedHostKey(signer.PublicKey()),
 	})
 	require.NoError(t, err)
 	client := ssh.NewClient(conn, chans, reqs)
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	var inputs []io.WriteCloser
 	var outputs []io.Reader
@@ -52,7 +52,7 @@ func TestRawSessionOutput(t *testing.T) {
 	for range 2 {
 		sess, err := client.NewSession()
 		require.NoError(t, err)
-		defer sess.Close()
+		defer func() { _ = sess.Close() }()
 		require.NoError(t, sess.RequestPty("xterm", 24, 80, ssh.TerminalModes{}))
 		input, err := sess.StdinPipe()
 		require.NoError(t, err)

--- a/host/internal/ssh_session_test.go
+++ b/host/internal/ssh_session_test.go
@@ -1,0 +1,79 @@
+package internal
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	gssh "charm.land/ssh"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+)
+
+func TestRawSessionOutput(t *testing.T) {
+	_, key, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	signer, err := ssh.NewSignerFromKey(key)
+	require.NoError(t, err)
+	srv := &gssh.Server{
+		HostSigners: []gssh.Signer{signer},
+		Handler: func(sess gssh.Session) {
+			_, _ = io.Copy(sess, sess)
+		},
+		ChannelHandlers: map[string]gssh.ChannelHandler{"session": rawSessionHandler},
+	}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	done := make(chan error, 1)
+	go func() { done <- srv.Serve(ln) }()
+	defer func() {
+		_ = srv.Close()
+		<-done
+	}()
+
+	raw, err := net.DialTimeout("tcp", ln.Addr().String(), 10*time.Second)
+	require.NoError(t, err)
+	defer raw.Close()
+	require.NoError(t, raw.SetDeadline(time.Now().Add(10*time.Second)))
+	conn, chans, reqs, err := ssh.NewClientConn(raw, ln.Addr().String(), &ssh.ClientConfig{
+		User: "guest", HostKeyCallback: ssh.FixedHostKey(signer.PublicKey()),
+	})
+	require.NoError(t, err)
+	client := ssh.NewClient(conn, chans, reqs)
+	defer client.Close()
+
+	var inputs []io.WriteCloser
+	var outputs []io.Reader
+	// Keep both sessions open on one connection. A raw channel stored on the
+	// connection context would send the first session's output to the second.
+	for range 2 {
+		sess, err := client.NewSession()
+		require.NoError(t, err)
+		defer sess.Close()
+		require.NoError(t, sess.RequestPty("xterm", 24, 80, ssh.TerminalModes{}))
+		input, err := sess.StdinPipe()
+		require.NoError(t, err)
+		output, err := sess.StdoutPipe()
+		require.NoError(t, err)
+		require.NoError(t, sess.Shell())
+		inputs = append(inputs, input)
+		outputs = append(outputs, output)
+	}
+
+	// Reading each write before sending the next forces CR and LF to cross
+	// separate SSH writes, where stateless newline normalization also corrupts
+	// an otherwise ordinary CRLF. No native PTY is needed, so this covers Windows.
+	for _, chunk := range []string{"HELLO   ", "\n", "HELLO", "\r", "\n", "\r\r\n", "\x1b[12;9Hpane\nnext", "\x00\t☃"} {
+		for i := range inputs {
+			_, err := io.WriteString(inputs[i], chunk)
+			require.NoError(t, err)
+			got := make([]byte, len(chunk))
+			_, err = io.ReadFull(outputs[i], got)
+			require.NoError(t, err)
+			require.Equal(t, chunk, string(got))
+		}
+	}
+}

--- a/internal/e2e/tmux_test.go
+++ b/internal/e2e/tmux_test.go
@@ -70,7 +70,8 @@ func TestTmux(t *testing.T) {
 
 			// Resize the outer terminals and require the nested tmux window to
 			// adopt the new dimensions delivered through Upterm's PTY handling.
-			out, err := exec.CommandContext(t.Context(), "tmux", "resize-window", "-t", h.session.Name+":0", "-x", "161", "-y", "20").CombinedOutput()
+			// The pane ID identifies its window regardless of the user's base-index.
+			out, err := exec.CommandContext(t.Context(), "tmux", "resize-window", "-t", h.host.Id, "-x", "161", "-y", "20").CombinedOutput()
 			require.NoError(t, err, "%s", out)
 			out, err = exec.CommandContext(t.Context(), "tmux", "display-message", "-p", "-t", h.host.Id, "#{pane_width}x#{pane_height}").Output()
 			require.NoError(t, err)

--- a/internal/e2e/tmux_test.go
+++ b/internal/e2e/tmux_test.go
@@ -1,0 +1,97 @@
+package e2e
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Sharing a tmux client and attaching each guest to tmux are both supported
+// workflows. Exercise real terminals so cursor movement, pane redraws and
+// window-change requests are checked alongside ordinary shell output.
+func TestTmux(t *testing.T) {
+	for _, mode := range []string{"shared", "forced attach"} {
+		t.Run(mode, func(t *testing.T) {
+			// After the outer window is split, host and guest each have 100 columns.
+			h := newTestHarness(t, 201)
+			socket := fmt.Sprintf("upterm-tmux-output-%d", time.Now().UnixNano())
+			tmuxQuery := func(args ...string) (string, error) {
+				out, err := exec.CommandContext(t.Context(), "tmux", append([]string{"-L", socket}, args...)...).CombinedOutput()
+				return strings.TrimSpace(string(out)), err
+			}
+			tmuxCommand := func(args ...string) string {
+				t.Helper()
+				out, err := tmuxQuery(args...)
+				require.NoError(t, err, "tmux %v: %s", args, out)
+				return out
+			}
+			// Use a separate tmux server from the one rendering the test's host
+			// and guest terminals. Cleanup touches only this test's server.
+			t.Cleanup(func() { _ = exec.Command("tmux", "-L", socket, "kill-server").Run() })
+			rc := h.writeFile("tmux-bashrc", "PS1='"+uptermPrompt+" '\nprintf '\033[H\033[2JTMUX_READY\\n'\n", 0600)
+			shell := fmt.Sprintf("bash --rcfile %q --noprofile", rc)
+			tmuxCommand("-f", "/dev/null", "new-session", "-d", "-s", "shared", "-x", "100", "-y", "23", shell)
+			tmuxCommand("set-option", "-g", "status", "off")
+
+			attach := fmt.Sprintf("env -u TMUX tmux -L %s attach-session -t shared", socket)
+			flags := "--accept"
+			if mode == "forced attach" {
+				flags += " --force-command '" + attach + "'"
+			}
+			sshCmd := h.startHost(flags)
+			require.NoError(t, h.host.SendLine(h.ctx, attach))
+			require.NoError(t, h.waitForText(h.host, "TMUX_READY", 10*time.Second))
+			client := h.splitPane(h.host)
+			h.connectClient(client, sshCmd)
+			require.NoError(t, h.waitForText(client, "TMUX_READY", 10*time.Second))
+
+			// Require rendered whitespace, which cannot match the echoed command.
+			require.NoError(t, client.SendLine(h.ctx, "printf '\\n%8s%s\\n' '' GUEST_INPUT"))
+			require.NoError(t, h.waitForText(h.host, "\n        GUEST_INPUT\n", 10*time.Second))
+			require.NoError(t, h.host.SendLine(h.ctx, "printf '\\n%8s%s\\n' '' HOST_INPUT"))
+			require.NoError(t, h.waitForText(client, "\n        HOST_INPUT\n", 10*time.Second))
+
+			// Split inside tmux, then check input from the guest reaches the new
+			// pane and both terminals render the same layout.
+			tmuxCommand("split-window", "-h", "-t", "shared:0", shell)
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				out, err := tmuxQuery("capture-pane", "-p", "-t", "shared:0.1")
+				require.NoError(c, err)
+				require.Contains(c, out, uptermPrompt)
+			}, 10*time.Second, 100*time.Millisecond)
+			require.NoError(t, client.SendLine(h.ctx, "printf '\\n%8s%s\\n' '' SPLIT_INPUT"))
+			require.NoError(t, h.waitForText(h.host, "        SPLIT_INPUT", 10*time.Second))
+			require.NoError(t, h.waitForText(client, "        SPLIT_INPUT", 10*time.Second))
+
+			// Resize the outer terminals and require the nested tmux window to
+			// adopt the new dimensions delivered through Upterm's PTY handling.
+			out, err := exec.CommandContext(t.Context(), "tmux", "resize-window", "-t", h.session.Name+":0", "-x", "161", "-y", "20").CombinedOutput()
+			require.NoError(t, err, "%s", out)
+			out, err = exec.CommandContext(t.Context(), "tmux", "display-message", "-p", "-t", h.host.Id, "#{pane_width}x#{pane_height}").Output()
+			require.NoError(t, err)
+			wantSize := strings.TrimSpace(string(out))
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				out, err := tmuxQuery("display-message", "-p", "-t", "shared:0", "#{window_width}x#{window_height}")
+				require.NoError(c, err)
+				require.Equal(c, wantSize, out)
+			}, 10*time.Second, 100*time.Millisecond, "tmux did not receive the terminal resize to %s", wantSize)
+
+			for _, tty := range strings.Fields(tmuxCommand("list-clients", "-F", "#{client_name}")) {
+				tmuxCommand("refresh-client", "-t", tty)
+			}
+			require.NoError(t, h.waitForText(client, "        SPLIT_INPUT", 10*time.Second))
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				hostScreen, hostErr := h.host.Capture(h.ctx)
+				guestScreen, guestErr := client.Capture(h.ctx)
+				require.NoError(c, hostErr)
+				require.NoError(c, guestErr)
+				require.Equal(c, hostScreen, guestScreen)
+			}, 10*time.Second, 100*time.Millisecond, "host and guest tmux displays differ after redraw and resize")
+		})
+	}
+}

--- a/io/query_filter.go
+++ b/io/query_filter.go
@@ -13,6 +13,7 @@ import (
 //   - OSC 10/11/12 queries (foreground/background/cursor color): ESC ] N ; ? BEL/ST
 //   - CSI 5 n (device status request)
 //   - CSI 6 n (cursor position request)
+//   - CSI 14 t / CSI 18 t (text area size in pixels / characters)
 //   - CSI c / CSI 0 c (primary device attributes)
 //   - CSI > c / CSI > 0 c (secondary device attributes)
 //   - CSI = c / CSI = 0 c (tertiary device attributes)
@@ -252,6 +253,12 @@ func (f *TerminalQueryFilter) isCSIQuery(finalByte byte) bool {
 	params := f.seqBuf[2 : n-1]
 
 	switch finalByte {
+	case 't':
+		// tmux queries its terminal size on attachment. A guest answering a
+		// replayed query injects a late reply into the shared shell's input.
+		if len(params) == 2 && params[0] == '1' && (params[1] == '4' || params[1] == '8') {
+			return true
+		}
 	case 'n':
 		// CSI 5 n - Device Status Report
 		// CSI 6 n - Cursor Position Request

--- a/io/query_filter.go
+++ b/io/query_filter.go
@@ -17,6 +17,7 @@ import (
 //   - CSI c / CSI 0 c (primary device attributes)
 //   - CSI > c / CSI > 0 c (secondary device attributes)
 //   - CSI = c / CSI = 0 c (tertiary device attributes)
+//   - CSI > q / CSI > 0 q (terminal name and version)
 type TerminalQueryFilter struct {
 	w      io.Writer
 	state  queryFilterState
@@ -253,6 +254,15 @@ func (f *TerminalQueryFilter) isCSIQuery(finalByte byte) bool {
 	params := f.seqBuf[2 : n-1]
 
 	switch finalByte {
+	case 'q':
+		// XTVERSION replies from guests can arrive after tmux has consumed
+		// the host's reply, so tmux treats them as shell input instead.
+		if len(params) == 1 && params[0] == '>' {
+			return true
+		}
+		if len(params) == 2 && params[0] == '>' && params[1] == '0' {
+			return true
+		}
 	case 't':
 		// tmux queries its terminal size on attachment. A guest answering a
 		// replayed query injects a late reply into the shared shell's input.

--- a/io/query_filter_test.go
+++ b/io/query_filter_test.go
@@ -75,6 +75,21 @@ func TestTerminalQueryFilter(t *testing.T) {
 			expected: nil,
 		},
 		{
+			name:     "filters terminal version query",
+			input:    []byte("\x1b[>q"),
+			expected: nil,
+		},
+		{
+			name:     "filters terminal version query with explicit default",
+			input:    []byte("\x1b[>0q"),
+			expected: nil,
+		},
+		{
+			name:     "passes cursor style and LED controls",
+			input:    []byte("\x1b[0 q\x1b[5 q\x1b[0q\x1b[1q"),
+			expected: []byte("\x1b[0 q\x1b[5 q\x1b[0q\x1b[1q"),
+		},
+		{
 			name:     "passes regular CSI sequences",
 			input:    []byte("\x1b[2J"), // clear screen
 			expected: []byte("\x1b[2J"),
@@ -223,6 +238,11 @@ func TestTerminalQueryFilter_SplitWrites(t *testing.T) {
 		{
 			name:     "tmux size queries split across writes",
 			writes:   [][]byte{[]byte("before\x1b[1"), []byte("8t\x1b"), []byte("[14"), []byte("tafter")},
+			expected: []byte("beforeafter"),
+		},
+		{
+			name:     "tmux version queries split across writes",
+			writes:   [][]byte{[]byte("before\x1b[>"), []byte("q\x1b"), []byte("[>0"), []byte("qafter")},
 			expected: []byte("beforeafter"),
 		},
 		{

--- a/io/query_filter_test.go
+++ b/io/query_filter_test.go
@@ -80,6 +80,21 @@ func TestTerminalQueryFilter(t *testing.T) {
 			expected: []byte("\x1b[2J"),
 		},
 		{
+			name:     "filters text area size query in pixels",
+			input:    []byte("\x1b[14t"),
+			expected: nil,
+		},
+		{
+			name:     "filters text area size query in characters",
+			input:    []byte("\x1b[18t"),
+			expected: nil,
+		},
+		{
+			name:     "passes window resize and title stack operations",
+			input:    []byte("\x1b[8;24;80t\x1b[22;0;0t\x1b[23;0;0t"),
+			expected: []byte("\x1b[8;24;80t\x1b[22;0;0t\x1b[23;0;0t"),
+		},
+		{
 			name:     "passes cursor movement",
 			input:    []byte("\x1b[10;20H"),
 			expected: []byte("\x1b[10;20H"),
@@ -204,6 +219,11 @@ func TestTerminalQueryFilter_SplitWrites(t *testing.T) {
 			name:     "CSI query split mid-sequence",
 			writes:   [][]byte{{0x1b, '['}, {'6', 'n'}},
 			expected: nil,
+		},
+		{
+			name:     "tmux size queries split across writes",
+			writes:   [][]byte{[]byte("before\x1b[1"), []byte("8t\x1b"), []byte("[14"), []byte("tafter")},
+			expected: []byte("beforeafter"),
 		},
 		{
 			name:     "non-query OSC split across writes",


### PR DESCRIPTION
Screen redraws lose indentation and split-pane output moves to the wrong columns because the SSH library rewrites LF to CRLF after Upterm's real PTY has already processed the output. The SSH-library switch in #250 reintroduced this conversion, which the previous fork disabled. Send guest output through the raw SSH channel while retaining the library's PTY requests, resize handling, callbacks, and subsystems.

Also filter tmux's text-area size queries (`CSI 14t` and `CSI 18t`) and terminal-version queries (`CSI >q` and `CSI >0q`) from shared guest output. Guests otherwise answer replayed queries intended for the host, injecting late replies into the shell and disrupting the first command. Window resize, title, cursor-style, and LED operations still pass through.

Tests cover byte preservation for live sharing, replay, forced commands, fragmented writes, and separate sessions on one SSH connection. A new tmux E2E test exercises shared and forced attachment, typing from both sides, indentation, splits, resizing, and matching host/guest redraws.

Validation:

- Non-E2E repository suite and final functional suite passed with `-race`.
- Complete SSH E2E suite passed against a local relay and the built CLI, including authorization and SFTP.
- tmux and terminal-sync E2E tests passed over WebSocket with `-race`.
- Real GNU Screen before/after reproduction: indentation and horizontal split rendering fail before and pass after, including forced attachment.
- Linux E2E checks passed with Ubuntu 24.04 and tmux 3.4 over SSH and WebSocket; a faster-polling diagnostic run passed 20 iterations of both tmux attachment modes after reproducing the version-query failure before the fix.
- macOS runtime checks passed with GNU Screen 4.00.03 and tmux 3.7c. Host tests also cross-compiled for Windows amd64.
- golangci-lint 2.13.2 (the CI version) passed with zero issues.

Fixes #288
Fixes #278
